### PR TITLE
Added SubscribeToKlineUpdatesAsync overload for multiple symbols

### DIFF
--- a/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApiExchangeData.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApiExchangeData.cs
@@ -86,6 +86,21 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
+    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToOpenInterestUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXOpenInterest>> onData, CancellationToken ct = default)
+    {
+        var subscription = new OKXSubscription<OKXOpenInterest>(_logger,
+           symbols.Select(s =>
+              new Objects.Sockets.Models.OKXSocketArgs
+              {
+                  Channel = "open-interest",
+                  Symbol = s
+              }).ToList(),
+            x => onData(x.WithDataTimestamp(x.Data.Time)), null, false);
+
+        return await _client.SubscribeInternalAsync(_client.GetUri("/ws/v5/public"), subscription, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
     public virtual async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval klineInterval, Action<DataEvent<OKXKline>> onData, CancellationToken ct = default)
     {
         var jc = EnumConverter.GetString(klineInterval);
@@ -107,7 +122,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string[] symbols, KlineInterval klineInterval, Action<DataEvent<OKXKline>> onData, CancellationToken ct = default)
+    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols, KlineInterval klineInterval, Action<DataEvent<OKXKline>> onData, CancellationToken ct = default)
     {
         var jc = EnumConverter.GetString(klineInterval);
         var subscription = new OKXSubscription<OKXKline>(_logger,
@@ -137,6 +152,21 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
                     Symbol = symbol
                 }
             }, x => onData(x.WithDataTimestamp(x.Data.Time)), null, false);
+
+        return await _client.SubscribeInternalAsync(_client.GetUri("/ws/v5/public"), subscription, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXTrade>> onData, CancellationToken ct = default)
+    {
+        var subscription = new OKXSubscription<OKXTrade>(_logger,
+           symbols.Select(s =>
+              new Objects.Sockets.Models.OKXSocketArgs
+              {
+                  Channel = "trades",
+                  Symbol = s
+              }).ToList(),
+            x => onData(x.WithDataTimestamp(x.Data.Time)), null, false);
 
         return await _client.SubscribeInternalAsync(_client.GetUri("/ws/v5/public"), subscription, ct).ConfigureAwait(false);
     }
@@ -174,6 +204,21 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
+    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToMarkPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXMarkPrice>> onData, CancellationToken ct = default)
+    {
+        var subscription = new OKXSubscription<OKXMarkPrice>(_logger,
+           symbols.Select(s =>
+              new Objects.Sockets.Models.OKXSocketArgs
+              {
+                  Channel = "mark-price",
+                  Symbol = s
+              }).ToList(),
+            x => onData(x.WithDataTimestamp(x.Data.Time)), null, false);
+
+        return await _client.SubscribeInternalAsync(_client.GetUri("/ws/v5/public"), subscription, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
     public virtual async Task<CallResult<UpdateSubscription>> SubscribeToMarkPriceKlineUpdatesAsync(string symbol, KlineInterval klineInterval, Action<DataEvent<OKXMiniKline[]>> onData, CancellationToken ct = default)
     {
         var jc = EnumConverter.GetString(klineInterval);
@@ -205,6 +250,21 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
+    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToPriceLimitUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXLimitPrice>> onData, CancellationToken ct = default)
+    {
+        var subscription = new OKXSubscription<OKXLimitPrice>(_logger,
+           symbols.Select(s =>
+              new Objects.Sockets.Models.OKXSocketArgs
+              {
+                  Channel = "price-limit",
+                  Symbol = s
+              }).ToList(),
+            x => onData(x.WithDataTimestamp(x.Data.Time)), null, false);
+
+        return await _client.SubscribeInternalAsync(_client.GetUri("/ws/v5/public"), subscription, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
     public virtual async Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, OrderBookType orderBookType, Action<DataEvent<OKXOrderBook>> onData, CancellationToken ct = default)
     {
         var jc = EnumConverter.GetString(orderBookType);
@@ -216,6 +276,26 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
                     Symbol = symbol,
                 }
             }, x => onData(x.WithDataTimestamp(x.Data.Time)), false);
+
+        return await _client.SubscribeInternalAsync(_client.GetUri("/ws/v5/public"), subscription, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, OrderBookType orderBookType, Action<DataEvent<OKXOrderBook>> onData, CancellationToken ct = default)
+    {
+        var jc = EnumConverter.GetString(orderBookType);
+        var subscription = new OKXBookSubscription(_logger,
+           symbols.Select(s =>
+              new Objects.Sockets.Models.OKXSocketArgs
+              {
+                  Channel = jc,
+                  Symbol = s
+              }).ToList(),
+            data =>
+            {
+                data.Data.Symbol = data.Symbol??"";
+                onData(data.WithDataTimestamp(data.Data.Time));
+            }, false);
 
         return await _client.SubscribeInternalAsync(_client.GetUri("/ws/v5/public"), subscription, ct).ConfigureAwait(false);
     }
@@ -252,6 +332,21 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
+    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToFundingRateUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXFundingRate>> onData, CancellationToken ct = default)
+    {
+        var subscription = new OKXSubscription<OKXFundingRate>(_logger,
+           symbols.Select(s =>
+              new Objects.Sockets.Models.OKXSocketArgs
+              {
+                  Channel = "funding-rate",
+                  Symbol = s
+              }).ToList(),
+            x => onData(x.WithDataTimestamp(x.Data.Timestamp)), null, false);
+
+        return await _client.SubscribeInternalAsync(_client.GetUri("/ws/v5/public"), subscription, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
     public virtual async Task<CallResult<UpdateSubscription>> SubscribeToIndexKlineUpdatesAsync(string symbol, KlineInterval klineInterval, Action<DataEvent<OKXMiniKline[]>> onData, CancellationToken ct = default)
     {
         var jc = EnumConverter.GetString(klineInterval);
@@ -278,6 +373,21 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
                     Symbol = symbol
                 }
             }, x => onData(x.WithDataTimestamp(x.Data.Time)), null, false);
+
+        return await _client.SubscribeInternalAsync(_client.GetUri("/ws/v5/public"), subscription, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToIndexTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXIndexTicker>> onData, CancellationToken ct = default)
+    {
+        var subscription = new OKXSubscription<OKXIndexTicker>(_logger,
+           symbols.Select(s =>
+              new Objects.Sockets.Models.OKXSocketArgs
+              {
+                  Channel = "index-tickers",
+                  Symbol = s
+              }).ToList(),
+            x => onData(x.WithDataTimestamp(x.Data.Time)), null, false);
 
         return await _client.SubscribeInternalAsync(_client.GetUri("/ws/v5/public"), subscription, ct).ConfigureAwait(false);
     }

--- a/OKX.Net/Enums/KlineInterval.cs
+++ b/OKX.Net/Enums/KlineInterval.cs
@@ -11,6 +11,12 @@ namespace OKX.Net.Enums;
 public enum KlineInterval
 {
     /// <summary>
+    /// 1s
+    /// </summary>
+    [Map("1s")]
+    OneSecond = 1,
+
+    /// <summary>
     /// 1m
     /// </summary>
     [Map("1m")]

--- a/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXSocketClientUnifiedApiExchangeData.cs
+++ b/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXSocketClientUnifiedApiExchangeData.cs
@@ -77,6 +77,17 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval period, Action<DataEvent<OKXKline>> onData, CancellationToken ct = default);
 
     /// <summary>
+    /// Subscribe to kline/candlesticks updates of multiple symbols. Data will be pushed every 500 ms.
+    /// <para><a href="https://www.okx.com/docs-v5/en/#order-book-trading-market-data-ws-candlesticks-channel" /></para>
+    /// </summary>
+    /// <param name="symbols">Array of symbols, for example `ETH-USDT`,'BTC-USDT'</param>
+    /// <param name="period">Kline interval</param>
+    /// <param name="onData">On Data Handler</param>
+    /// <param name="ct">Cancellation Token</param>
+    /// <returns></returns>
+    Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string[] symbols, KlineInterval period, Action<DataEvent<OKXKline>> onData, CancellationToken ct = default);
+
+    /// <summary>
     /// Subscribe to the mark price updates. Data will be pushed every 200 ms when the mark price changes, and will be pushed every 10 seconds when the mark price does not change.
     /// <para><a href="https://www.okx.com/docs-v5/en/#public-data-websocket-mark-price-channel" /></para>
     /// </summary>

--- a/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXSocketClientUnifiedApiExchangeData.cs
+++ b/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXSocketClientUnifiedApiExchangeData.cs
@@ -35,6 +35,16 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     Task<CallResult<UpdateSubscription>> SubscribeToFundingRateUpdatesAsync(string symbol, Action<DataEvent<OKXFundingRate>> onData, CancellationToken ct = default);
 
     /// <summary>
+    /// Subscribe to funding rate updates. Data will be pushed every minute.
+    /// <para><a href="https://www.okx.com/docs-v5/en/#public-data-websocket-funding-rate-channel" /></para>
+    /// </summary>
+    /// <param name="symbols">Array of symbols, for example `ETH-USDT-SWAP`,'BTC-USDT-SWAP'</param>
+    /// <param name="onData">On Data Handler</param>
+    /// <param name="ct">Cancellation Token</param>
+    /// <returns></returns>
+    Task<CallResult<UpdateSubscription>> SubscribeToFundingRateUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXFundingRate>> onData, CancellationToken ct = default);
+
+    /// <summary>
     /// Subscribe to the index klime/candlesticks updates. Data will be pushed every 500 ms.
     /// <para><a href="https://www.okx.com/docs-v5/en/#public-data-websocket-index-candlesticks-channel" /></para>
     /// </summary>
@@ -56,6 +66,16 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     Task<CallResult<UpdateSubscription>> SubscribeToIndexTickerUpdatesAsync(string symbol, Action<DataEvent<OKXIndexTicker>> onData, CancellationToken ct = default);
 
     /// <summary>
+    /// Subscribe to index tickers data updates
+    /// <para><a href="https://www.okx.com/docs-v5/en/#public-data-websocket-index-tickers-channel" /></para>
+    /// </summary>
+    /// <param name="symbols">Array of symbols, for example `ETH-USDT`,'BTC-USDT'</param>
+    /// <param name="onData">On Data Handler</param>
+    /// <param name="ct">Cancellation Token</param>
+    /// <returns></returns>
+    Task<CallResult<UpdateSubscription>> SubscribeToIndexTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXIndexTicker>> onData, CancellationToken ct = default);
+
+    /// <summary>
     /// Subscribe to the open interest updates. Data will by pushed every 3 seconds.
     /// <para><a href="https://www.okx.com/docs-v5/en/#public-data-websocket-open-interest-channel" /></para>
     /// </summary>
@@ -64,6 +84,16 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
     Task<CallResult<UpdateSubscription>> SubscribeToOpenInterestUpdatesAsync(string symbol, Action<DataEvent<OKXOpenInterest>> onData, CancellationToken ct = default);
+
+    /// <summary>
+    /// Subscribe to the open interest updates. Data will by pushed every 3 seconds.
+    /// <para><a href="https://www.okx.com/docs-v5/en/#public-data-websocket-open-interest-channel" /></para>
+    /// </summary>
+    /// <param name="symbols">Array of symbols, for example `ETH-USDT-SWAP`,'BTC-USDT-SWAP'</param>
+    /// <param name="onData">On Data Handler</param>
+    /// <param name="ct">Cancellation Token</param>
+    /// <returns></returns>
+    Task<CallResult<UpdateSubscription>> SubscribeToOpenInterestUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXOpenInterest>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to kline/candlesticks updates of a symbol. Data will be pushed every 500 ms.
@@ -85,7 +115,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string[] symbols, KlineInterval period, Action<DataEvent<OKXKline>> onData, CancellationToken ct = default);
+    Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols, KlineInterval period, Action<DataEvent<OKXKline>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to the mark price updates. Data will be pushed every 200 ms when the mark price changes, and will be pushed every 10 seconds when the mark price does not change.
@@ -96,6 +126,16 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
     Task<CallResult<UpdateSubscription>> SubscribeToMarkPriceUpdatesAsync(string symbol, Action<DataEvent<OKXMarkPrice>> onData, CancellationToken ct = default);
+
+    /// <summary>
+    /// Subscribe to the mark price updates. Data will be pushed every 200 ms when the mark price changes, and will be pushed every 10 seconds when the mark price does not change.
+    /// <para><a href="https://www.okx.com/docs-v5/en/#public-data-websocket-mark-price-channel" /></para>
+    /// </summary>
+    /// <param name="symbols">Array of symbols, for example `BTC-USD-SWAP`, `ETH-USD-SWAP` </param>
+    /// <param name="onData">On Data Handler</param>
+    /// <param name="ct">Cancellation Token</param>
+    /// <returns></returns>
+    Task<CallResult<UpdateSubscription>> SubscribeToMarkPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXMarkPrice>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to mark price kline/candlesticks updates. Data will be pushed every 500 ms.
@@ -135,6 +175,22 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, OrderBookType orderBookType, Action<DataEvent<OKXOrderBook>> onData, CancellationToken ct = default);
 
     /// <summary>
+    /// Subscribe to order book data updates.<br />
+    /// Use OrderBookType.OrderBook for 400 depth levels, OrderBook_5 for 5 depth levels, OrderBook_50_l2_TBT tick-by-tick 50 depth levels, and OrderBook_l2_TBT for tick-by-tick 400 depth levels.<br />
+    /// OrderBookType.OrderBook: 400 depth levels will be pushed in the initial full snapshot. Incremental data will be pushed every 100 ms when there is change in order book.<br />
+    /// OrderBookType.OrderBook_5: 5 depth levels will be pushed every time.Data will be pushed every 200 ms when there is change in order book.<br />
+    /// OrderBookType.OrderBook_50_l2_TBT: 50 depth levels will be pushed in the initial full snapshot. Incremental data will be pushed tick by tick, i.e.whenever there is change in order book.<br />
+    /// OrderBookType.OrderBook_l2_TBT: 400 depth levels will be pushed in the initial full snapshot. Incremental data will be pushed tick by tick, i.e.whenever there is change in order book.
+    /// <para><a href="https://www.okx.com/docs-v5/en/#order-book-trading-market-data-ws-order-book-channel" /></para>
+    /// </summary>
+    /// <param name="symbols">Array of symbols, for example `BTC-USD`, `ETH-USD` </param>
+    /// <param name="orderBookType">Order Book Type</param>
+    /// <param name="onData">On Data Handler</param>
+    /// <param name="ct">Cancellation Token</param>
+    /// <returns></returns>
+    Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, OrderBookType orderBookType, Action<DataEvent<OKXOrderBook>> onData, CancellationToken ct = default);
+
+    /// <summary>
     /// Subscribe to the maximum buy price and minimum sell price of the instrument updates. Data will be pushed every 5 seconds when there are changes in limits, and will not be pushed when there is no changes on limit.
     /// <para><a href="https://www.okx.com/docs-v5/en/#public-data-websocket-price-limit-channel" /></para>
     /// </summary>
@@ -143,6 +199,16 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
     Task<CallResult<UpdateSubscription>> SubscribeToPriceLimitUpdatesAsync(string symbol, Action<DataEvent<OKXLimitPrice>> onData, CancellationToken ct = default);
+
+    /// <summary>
+    /// Subscribe to the maximum buy price and minimum sell price of the instrument updates. Data will be pushed every 5 seconds when there are changes in limits, and will not be pushed when there is no changes on limit.
+    /// <para><a href="https://www.okx.com/docs-v5/en/#public-data-websocket-price-limit-channel" /></para>
+    /// </summary>
+    /// <param name="symbols">Array of symbols, for example `BTC-USD`, `ETH-USD` </param>
+    /// <param name="onData">On Data Handler</param>
+    /// <param name="ct">Cancellation Token</param>
+    /// <returns></returns>
+    Task<CallResult<UpdateSubscription>> SubscribeToPriceLimitUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXLimitPrice>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to symbols updates. The instruments will be pushed if there's any change to the instrument’s state (such as delivery of FUTURES, exercise of OPTION, listing of new contracts / trading pairs, trading suspension, etc.).
@@ -177,7 +243,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// Subscribe to the last traded price updates, bid price, ask price and 24-hour trading volume of instruments. Data will be pushed every 100 ms.
     /// <para><a href="https://www.okx.com/docs-v5/en/#order-book-trading-market-data-ws-tickers-channel" /></para>
     /// </summary>
-    /// <param name="symbols">Symbol, for example `ETH-USDT`</param>
+    /// <param name="symbols">Array of symbols, for example `BTC-USD`, `ETH-USD` </param>
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
@@ -192,5 +258,15 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
     Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<OKXTrade>> onData, CancellationToken ct = default);
+
+    /// <summary>
+    /// Subscribe to the recent trades data updates. Data will be pushed whenever there is a trade.
+    /// <para><a href="https://www.okx.com/docs-v5/en/#order-book-trading-market-data-ws-trades-channel" /></para>
+    /// </summary>
+    /// <param name="symbols">Array of symbols, for example `BTC-USD`, `ETH-USD` </param>
+    /// <param name="onData">On Data Handler</param>
+    /// <param name="ct">Cancellation Token</param>
+    /// <returns></returns>
+    Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXTrade>> onData, CancellationToken ct = default);
 
 }


### PR DESCRIPTION
Okx.Net supports subscription for the kline updates of multiple symbols in one subscription. Maybe it would have been useful to add similar overloads for other subscription types such as UpdatePrice etc. as well, please let me know if to add those too...