### PR TITLE
CryptoExchange.Net V12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ description: Use OKX.Net when generating C#/.NET code that interacts with the OK
 
 ## Quick Decision
 
-If the user asks for OKX API access in C#/.NET, **use OKX.Net**. Do not write raw `HttpClient` calls to OKX endpoints. OKX.Net handles signing, timestamping, rate limit integration, response parsing, WebSocket reconnects, and the `WebCallResult<T>` / `CallResult<T>` error model.
+If the user asks for OKX API access in C#/.NET, **use OKX.Net**. Do not write raw `HttpClient` calls to OKX endpoints. OKX.Net handles signing, timestamping, rate limit integration, response parsing, WebSocket reconnects, and the `HttpResult<T>` / `WebSocketResult<T>` error model.
 
 For multi-exchange code, use `CryptoExchange.Net.SharedApis` via `new OKXRestClient().UnifiedApi.SharedClient`.
 
@@ -39,7 +39,7 @@ var publicClient = new OKXRestClient();
 
 ## Core Pattern: Result Handling
 
-Every REST method returns `WebCallResult<T>`. Every WebSocket subscription or socket request returns `CallResult<T>`. Always check `.Success` before reading `.Data`.
+Every REST method returns `HttpResult<T>`. Every WebSocket subscription or socket request returns `WebSocketResult<T>`. Always check `.Success` before reading `.Data`.
 
 ```csharp
 var ticker = await restClient.UnifiedApi.ExchangeData.GetTickerAsync("BTC-USDT");

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,9 @@ description: Use OKX.Net when generating C#/.NET code that interacts with the OK
 
 ## Quick Decision
 
-If the user asks for OKX API access in C#/.NET, **use OKX.Net**. Do not write raw `HttpClient` calls to OKX endpoints. OKX.Net handles signing, timestamping, rate limit integration, response parsing, WebSocket reconnects, and the `HttpResult<T>` / `WebSocketResult<T>` error model.
+If the user asks for OKX API access in C#/.NET, **use OKX.Net**. Do not write raw `HttpClient` calls to OKX endpoints. OKX.Net handles signing, timestamping, rate limit integration, response parsing, WebSocket reconnects, and the `HttpResult<T>` / `HttpResult` / `WebSocketResult<UpdateSubscription>` / `QueryResult<T>` result model.
 
-For multi-exchange code, use `CryptoExchange.Net.SharedApis` via `new OKXRestClient().UnifiedApi.SharedClient`.
+For multi-exchange code, use `CryptoExchange.Net.SharedApis` via `new OKXRestClient().UnifiedApi.SharedClient`. Use `.SharedClient.Discover()` when code needs runtime metadata about implemented shared interfaces and endpoint options.
 
 ## Installation
 
@@ -39,7 +39,7 @@ var publicClient = new OKXRestClient();
 
 ## Core Pattern: Result Handling
 
-Every REST method returns `HttpResult<T>`. Every WebSocket subscription or socket request returns `WebSocketResult<T>`. Always check `.Success` before reading `.Data`.
+REST methods return `HttpResult<T>` or `HttpResult`. WebSocket subscription methods return `WebSocketResult<UpdateSubscription>`. Socket API request/response methods return `QueryResult<T>`. Shared symbol/cache helper methods can return `ExchangeCallResult<T>`. Always check `.Success` before reading `.Data`.
 
 ```csharp
 var ticker = await restClient.UnifiedApi.ExchangeData.GetTickerAsync("BTC-USDT");
@@ -161,6 +161,8 @@ var okxShared = new OKXRestClient().UnifiedApi.SharedClient;
 var symbol = new SharedSymbol(TradingMode.Spot, "BTC", "USDT");
 var ticker = await okxShared.GetSpotTickerAsync(new GetTickerRequest(symbol));
 ```
+
+Call `okxShared.Discover()` to inspect supported shared interfaces, request options, and subscription options at runtime.
 
 Available shared REST interfaces include `ISpotTickerRestClient`, `ISpotOrderRestClient`, `IFuturesOrderRestClient`, `IBalanceRestClient`, `IKlineRestClient`, `IOrderBookRestClient`, `IFundingRateRestClient`, `ILeverageRestClient`, `IWithdrawalRestClient`, and more. Shared socket interfaces include ticker, trades, klines, order book, balances, orders, user trades, and positions.
 

--- a/Examples/ai-friendly/03-websocket.cs
+++ b/Examples/ai-friendly/03-websocket.cs
@@ -4,6 +4,7 @@ using OKX.Net.Enums;
 
 var socketClient = new OKXSocketClient();
 
+// Subscription methods return WebSocketResult<UpdateSubscription>.
 var tickerSubscription = await socketClient.UnifiedApi.ExchangeData.SubscribeToTickerUpdatesAsync(
     "ETH-USDT",
     update =>

--- a/Examples/ai-friendly/04-multi-exchange.cs
+++ b/Examples/ai-friendly/04-multi-exchange.cs
@@ -4,6 +4,8 @@ using OKX.Net.Clients;
 // SharedApis are exchange-agnostic wrappers from CryptoExchange.Net.
 // OKX exposes them through UnifiedApi.SharedClient.
 var okxShared = new OKXRestClient().UnifiedApi.SharedClient;
+var capabilities = okxShared.Discover();
+Console.WriteLine($"Shared features: {capabilities.Features.Count(x => x.Supported)}");
 
 var spotSymbol = new SharedSymbol(TradingMode.Spot, "ETH", "USDT");
 var ticker = await okxShared.GetSpotTickerAsync(new GetTickerRequest(spotSymbol));

--- a/Examples/ai-friendly/05-error-handling.cs
+++ b/Examples/ai-friendly/05-error-handling.cs
@@ -4,6 +4,9 @@ using OKX.Net.Enums;
 
 var client = new OKXRestClient();
 
+// REST methods return HttpResult<T> or HttpResult.
+// Socket API request/response methods return QueryResult<T>; socket subscriptions return
+// WebSocketResult<UpdateSubscription>. Check Success before reading Data for each result type.
 var ticker = await client.UnifiedApi.ExchangeData.GetTickerAsync("ETH-USDT");
 if (!ticker.Success)
 {

--- a/Examples/ai-friendly/05-error-handling.cs
+++ b/Examples/ai-friendly/05-error-handling.cs
@@ -24,15 +24,15 @@ if (!klines.Success)
 
 Console.WriteLine($"Received {klines.Data.Length} candles");
 
-static void LogError<T>(string operation, WebCallResult<T> result)
+static void LogError<T>(string operation, HttpResult<T> result)
 {
     Console.WriteLine($"{operation} failed");
     Console.WriteLine($"Code: {result.Error?.Code}");
     Console.WriteLine($"Message: {result.Error?.Message}");
 }
 
-static async Task<WebCallResult<T>> ExecuteWithTransientRetryAsync<T>(
-    Func<Task<WebCallResult<T>>> action)
+static async Task<HttpResult<T>> ExecuteWithTransientRetryAsync<T>(
+    Func<Task<HttpResult<T>>> action)
 {
     var first = await action();
     if (first.Success || first.Error?.IsTransient != true)

--- a/Examples/ai-friendly/README.md
+++ b/Examples/ai-friendly/README.md
@@ -14,8 +14,8 @@ These examples are optimized for AI coding assistants and quick onboarding. Each
 | `01-unified-quickstart.cs` | Client setup, public ticker, authenticated balance, spot limit order, order lookup |
 | `02-derivatives.cs` | Swap/futures flow: symbols, leverage, market order, positions, close position |
 | `03-websocket.cs` | Public ticker/klines and private order streams with proper teardown |
-| `04-multi-exchange.cs` | `CryptoExchange.Net.SharedApis` pattern for exchange-agnostic code |
-| `05-error-handling.cs` | `HttpResult` patterns, transient retry, common error metadata |
+| `04-multi-exchange.cs` | `CryptoExchange.Net.SharedApis` pattern and discovery metadata for exchange-agnostic code |
+| `05-error-handling.cs` | `HttpResult`, `QueryResult`, and `WebSocketResult` patterns, transient retry, common error metadata |
 
 ## Running
 

--- a/Examples/ai-friendly/README.md
+++ b/Examples/ai-friendly/README.md
@@ -15,7 +15,7 @@ These examples are optimized for AI coding assistants and quick onboarding. Each
 | `02-derivatives.cs` | Swap/futures flow: symbols, leverage, market order, positions, close position |
 | `03-websocket.cs` | Public ticker/klines and private order streams with proper teardown |
 | `04-multi-exchange.cs` | `CryptoExchange.Net.SharedApis` pattern for exchange-agnostic code |
-| `05-error-handling.cs` | `WebCallResult` patterns, transient retry, common error metadata |
+| `05-error-handling.cs` | `HttpResult` patterns, transient retry, common error metadata |
 
 ## Running
 

--- a/OKX.Net.UnitTests/OXKRestClientTests.cs
+++ b/OKX.Net.UnitTests/OXKRestClientTests.cs
@@ -92,7 +92,7 @@ namespace OKX.Net.UnitTests
                     return headers["OK-ACCESS-SIGN"].ToString();
                 },
                 "SQ8OzSqaLcC5tF3MMKwonxGUXwGfGPkM60flrI/UJjo=",
-                new Dictionary<string, object>
+                new Parameters(OKXExchange._parameterSerializationSettings)
                 {
                     { "instId", "BTC-USDT" },
                     { "lever", "5" },

--- a/OKX.Net.UnitTests/RestRequestTests.cs
+++ b/OKX.Net.UnitTests/RestRequestTests.cs
@@ -209,7 +209,7 @@ namespace OKX.Net.UnitTests
             await tester.ValidateAsync(c => c.UnifiedApi.CopyTrading.AmendLeadingInstrumentsAsync(["BTC-USDT"]), "AmendLeadingInstruments");
         }
 
-        private static bool IsAuthenticated(WebCallResult result)
+        private static bool IsAuthenticated(IHttpResult result)
         {
             return result.RequestHeaders.Any(h => h.Key == "OK-ACCESS-SIGN");
         }

--- a/OKX.Net.UnitTests/SocketSubscriptionTests.cs
+++ b/OKX.Net.UnitTests/SocketSubscriptionTests.cs
@@ -30,7 +30,7 @@ namespace OKX.Net.UnitTests
 
             }), logger);
 
-            var tester = new SocketSubscriptionValidator<OKXSocketClient>(client, "Subscriptions/Unified/ExchangeData", "wss://ws.okx.com:8443", "data");
+            var tester = new SocketSubscriptionValidator<OKXSocketClient>(client, "Subscriptions/Unified/ExchangeData", "wss://ws.okx.com:8443/ws/v5/business", "data");
             await tester.ValidateConcurrentAsync<OKXKline>(
                 (c, handler) => c.UnifiedApi.ExchangeData.SubscribeToKlineUpdatesAsync("ETH-USDT", KlineInterval.OneDay, handler),
                 (c, handler) => c.UnifiedApi.ExchangeData.SubscribeToKlineUpdatesAsync("ETH-USDT", KlineInterval.OneHour, handler),

--- a/OKX.Net/Clients/OKXRestClient.cs
+++ b/OKX.Net/Clients/OKXRestClient.cs
@@ -39,7 +39,7 @@ public class OKXRestClient : BaseRestClient<OKXEnvironment, OKXCredentials>, IOK
     {
         Initialize(options.Value);
 
-        UnifiedApi = AddApiClient(new OKXRestClientUnifiedApi(_logger, httpClient, options.Value));
+        UnifiedApi = AddApiClient(new OKXRestClientUnifiedApi(loggerFactory, httpClient, options.Value));
     }
     #endregion
 

--- a/OKX.Net/Clients/OKXSocketClient.cs
+++ b/OKX.Net/Clients/OKXSocketClient.cs
@@ -36,7 +36,7 @@ public class OKXSocketClient : BaseSocketClient<OKXEnvironment, OKXCredentials>,
     {
         Initialize(options.Value);
 
-        UnifiedApi = AddApiClient(new OKXSocketClientUnifiedApi(_logger, options.Value));
+        UnifiedApi = AddApiClient(new OKXSocketClientUnifiedApi(loggerFactory, options.Value));
     }
     #endregion
 

--- a/OKX.Net/Clients/OKXUserClientProvider.cs
+++ b/OKX.Net/Clients/OKXUserClientProvider.cs
@@ -2,22 +2,22 @@
 using OKX.Net.Objects.Options;
 using Microsoft.Extensions.Options;
 using System.Collections.Concurrent;
+using CryptoExchange.Net.Clients;
 
 namespace OKX.Net.Clients
 {
     /// <inheritdoc />
-    public class OKXUserClientProvider : IOKXUserClientProvider
+    public class OKXUserClientProvider : UserClientProvider<
+        IOKXRestClient,
+        IOKXSocketClient,
+        OKXRestOptions,
+        OKXSocketOptions,
+        OKXCredentials,
+        OKXEnvironment
+        >, IOKXUserClientProvider
     {
-        private ConcurrentDictionary<string, IOKXRestClient> _restClients = new ConcurrentDictionary<string, IOKXRestClient>();
-        private ConcurrentDictionary<string, IOKXSocketClient> _socketClients = new ConcurrentDictionary<string, IOKXSocketClient>();
-
-        private readonly IOptions<OKXRestOptions> _restOptions;
-        private readonly IOptions<OKXSocketOptions> _socketOptions;
-        private readonly HttpClient _httpClient;
-        private readonly ILoggerFactory? _loggerFactory;
-
         /// <inheritdoc />
-        public string ExchangeName => OKXExchange.ExchangeName;
+        public override string ExchangeName => OKXExchange.ExchangeName;
 
         /// <summary>
         /// ctor
@@ -36,97 +36,15 @@ namespace OKX.Net.Clients
             ILoggerFactory? loggerFactory,
             IOptions<OKXRestOptions> restOptions,
             IOptions<OKXSocketOptions> socketOptions)
+            : base(httpClient, loggerFactory, restOptions, socketOptions)
         {
-            _httpClient = httpClient ?? new HttpClient();
-            _httpClient.Timeout = restOptions.Value.RequestTimeout;
-            _loggerFactory = loggerFactory;
-            _restOptions = restOptions;
-            _socketOptions = socketOptions;
         }
 
         /// <inheritdoc />
-        public void InitializeUserClient(string userIdentifier, OKXCredentials credentials, OKXEnvironment? environment = null)
-        {
-            CreateRestClient(userIdentifier, credentials, environment);
-            CreateSocketClient(userIdentifier, credentials, environment);
-        }
-
+        protected override IOKXRestClient ConstructRestClient(HttpClient client, ILoggerFactory? loggerFactory, IOptions<OKXRestOptions> options)
+            => new OKXRestClient(client, loggerFactory, options);
         /// <inheritdoc />
-        public void ClearUserClients(string userIdentifier)
-        {
-            _restClients.TryRemove(userIdentifier, out _);
-            _socketClients.TryRemove(userIdentifier, out _);
-        }
-
-        /// <inheritdoc />
-        public IOKXRestClient GetRestClient(string userIdentifier, OKXCredentials? credentials = null, OKXEnvironment? environment = null)
-        {
-            if (!_restClients.TryGetValue(userIdentifier, out var client) || client.Disposed)
-                client = CreateRestClient(userIdentifier, credentials, environment);
-
-            return client;
-        }
-
-        /// <inheritdoc />
-        public IOKXSocketClient GetSocketClient(string userIdentifier, OKXCredentials? credentials = null, OKXEnvironment? environment = null)
-        {
-            if (!_socketClients.TryGetValue(userIdentifier, out var client) || client.Disposed)
-                client = CreateSocketClient(userIdentifier, credentials, environment);
-
-            return client;
-        }
-
-        private IOKXRestClient CreateRestClient(string userIdentifier, OKXCredentials? credentials, OKXEnvironment? environment)
-        {
-            var clientRestOptions = SetRestEnvironment(environment);
-            var client = new OKXRestClient(_httpClient, _loggerFactory, clientRestOptions);
-            if (credentials != null)
-            {
-                client.SetApiCredentials(credentials);
-                _restClients[userIdentifier] = client;
-            }
-            return client;
-        }
-
-        private IOKXSocketClient CreateSocketClient(string userIdentifier, OKXCredentials? credentials, OKXEnvironment? environment)
-        {
-            var clientSocketOptions = SetSocketEnvironment(environment);
-            var client = new OKXSocketClient(clientSocketOptions!, _loggerFactory);
-            if (credentials != null)
-            {
-                client.SetApiCredentials(credentials);
-                _socketClients[userIdentifier] = client;
-            }
-            return client;
-        }
-
-        private IOptions<OKXRestOptions> SetRestEnvironment(OKXEnvironment? environment)
-        {
-            if (environment == null)
-                return _restOptions;
-
-            var newRestClientOptions = new OKXRestOptions();
-            var restOptions = _restOptions.Value.Set(newRestClientOptions);
-            newRestClientOptions.Environment = environment;
-            return Options.Create(newRestClientOptions);
-        }
-
-        private IOptions<OKXSocketOptions> SetSocketEnvironment(OKXEnvironment? environment)
-        {
-            if (environment == null)
-                return _socketOptions;
-
-            var newSocketClientOptions = new OKXSocketOptions();
-            var restOptions = _socketOptions.Value.Set(newSocketClientOptions);
-            newSocketClientOptions.Environment = environment;
-            return Options.Create(newSocketClientOptions);
-        }
-
-        private static T ApplyOptionsDelegate<T>(Action<T>? del) where T : new()
-        {
-            var opts = new T();
-            del?.Invoke(opts);
-            return opts;
-        }
+        protected override IOKXSocketClient ConstructSocketClient(ILoggerFactory? loggerFactory, IOptions<OKXSocketOptions> options)
+            => new OKXSocketClient(options, loggerFactory);
     }
 }

--- a/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApi.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApi.cs
@@ -55,7 +55,12 @@ internal partial class OKXRestClientUnifiedApi : RestApiClient<OKXEnvironment, O
 
     /// <inheritdoc />
     public override string FormatSymbol(string baseAsset, string quoteAsset, TradingMode tradingMode, DateTime? deliverTime = null)
-        => OKXExchange.FormatSymbol(baseAsset, quoteAsset, tradingMode, deliverTime);
+    {
+        if (EnvironmentName == OKXEnvironment.Europe.Name)
+            return OKXExchange.FormatSymbolEurope(baseAsset, quoteAsset, tradingMode, deliverTime);
+        else
+            return OKXExchange.FormatSymbol(baseAsset, quoteAsset, tradingMode, deliverTime);
+    }
 
     internal async Task<HttpResult<T>> SendAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null, Dictionary<string, string>? requestHeaders = null, string? rateLimitKeySuffix = null) where T : class
     {

--- a/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApi.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApi.cs
@@ -29,7 +29,7 @@ internal partial class OKXRestClientUnifiedApi : RestApiClient<OKXEnvironment, O
     public IOKXRestClientUnifiedApiShared SharedClient => this;
 
     internal OKXRestClientUnifiedApi(ILogger logger, HttpClient? httpClient, OKXRestOptions options)
-            : base(logger, httpClient, options.Environment.RestAddress, options, options.UnifiedOptions)
+            : base(logger, OKXExchange.Metadata.Id, httpClient, options.Environment.RestAddress, options, options.UnifiedOptions)
     {
         Account = new OKXRestClientUnifiedApiAccount(this);
         ExchangeData = new OKXRestClientUnifiedApiExchangeData(this);
@@ -57,37 +57,34 @@ internal partial class OKXRestClientUnifiedApi : RestApiClient<OKXEnvironment, O
     public override string FormatSymbol(string baseAsset, string quoteAsset, TradingMode tradingMode, DateTime? deliverTime = null)
         => OKXExchange.FormatSymbol(baseAsset, quoteAsset, tradingMode, deliverTime);
 
-    internal async Task<WebCallResult<T>> SendToAddressAsync<T>(string baseAddress, RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null, Dictionary<string, string>? requestHeaders = null, string? rateLimitKeySuffix = null) where T : class
+    internal async Task<HttpResult<T>> SendAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null, Dictionary<string, string>? requestHeaders = null, string? rateLimitKeySuffix = null) where T : class
     {
-        var result = await base.SendAsync<OKXRestApiResponse<T>>(baseAddress, definition, parameters, cancellationToken, requestHeaders, weight, rateLimitKeySuffix: rateLimitKeySuffix).ConfigureAwait(false);
-        if (!result.Success) return result.AsError<T>(result.Error!);
-        if (result.Data.ErrorCode > 0) return result.AsError<T>(new ServerError(result.Data.ErrorCode, GetErrorInfo(result.Data.ErrorCode, result.Data.ErrorMessage!)));
+        var result = await base.SendAsync<OKXRestApiResponse<T>>(definition, parameters, cancellationToken, requestHeaders, weight, rateLimitKeySuffix: rateLimitKeySuffix).ConfigureAwait(false);
+        if (!result.Success) return HttpResult.Fail<T>(result);
+        if (result.Data.ErrorCode > 0) return HttpResult.Fail<T>(result, new ServerError(result.Data.ErrorCode, GetErrorInfo(result.Data.ErrorCode, result.Data.ErrorMessage!)));
 
-        return result.As<T>(result.Data.Data);
+        return HttpResult.Ok(result, result.Data.Data!);
     }
 
-    internal Task<WebCallResult<T>> SendAsync<T>(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null, Dictionary<string, string>? requestHeaders = null, string? rateLimitKeySuffix = null) where T : class
-        => SendToAddressAsync<T>(BaseAddress, definition, parameters, cancellationToken, weight, requestHeaders, rateLimitKeySuffix: rateLimitKeySuffix);
-
-    internal async Task<WebCallResult<T>> SendRawAsync<T>(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null, Dictionary<string, string>? requestHeaders = null, string? rateLimitKeySuffix = null) where T : class
+    internal async Task<HttpResult<T>> SendRawAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null, Dictionary<string, string>? requestHeaders = null, string? rateLimitKeySuffix = null) where T : class
     {
-        return await base.SendAsync<T>(BaseAddress, definition, parameters, cancellationToken, null, weight, rateLimitKeySuffix: rateLimitKeySuffix).ConfigureAwait(false);
+        return await base.SendAsync<T>(definition, parameters, cancellationToken, null, weight, rateLimitKeySuffix: rateLimitKeySuffix).ConfigureAwait(false);
     }
 
-    internal async Task<WebCallResult<T>> SendGetSingleAsync<T>(RequestDefinition definition, ParameterCollection? parameters, CancellationToken cancellationToken, int? weight = null, Dictionary<string, string>? requestHeaders = null, string? rateLimitKeySuffix = null) where T : class
+    internal async Task<HttpResult<T>> SendGetSingleAsync<T>(RequestDefinition definition, Parameters? parameters, CancellationToken cancellationToken, int? weight = null, Dictionary<string, string>? requestHeaders = null, string? rateLimitKeySuffix = null) where T : class
     {
-        var result = await SendToAddressAsync<T[]>(BaseAddress, definition, parameters, cancellationToken, weight, requestHeaders, rateLimitKeySuffix: rateLimitKeySuffix).ConfigureAwait(false);
-        if (!result)
-            return result.As<T>(default);
+        var result = await SendAsync<T[]>(definition, parameters, cancellationToken, weight, requestHeaders, rateLimitKeySuffix: rateLimitKeySuffix).ConfigureAwait(false);
+        if (!result.Success)
+            return HttpResult.Fail<T>(result);
 
         if (!result.Data.Any())
-            return result.AsError<T>(new ServerError(ErrorInfo.Unknown with { Message = "No response data" }));
+            return HttpResult.Fail<T>(result, new ServerError(ErrorInfo.Unknown with { Message = "No response data" }));
 
-        return result.As<T>(result.Data?.FirstOrDefault());
+        return HttpResult.Ok(result, result.Data.First());
     }
 
     /// <inheritdoc />
-    protected override Task<WebCallResult<DateTime>> GetServerTimestampAsync()
+    protected override Task<HttpResult<DateTime>> GetServerTimestampAsync()
         => ExchangeData.GetServerTimeAsync();
 
 }

--- a/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApi.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApi.cs
@@ -28,8 +28,8 @@ internal partial class OKXRestClientUnifiedApi : RestApiClient<OKXEnvironment, O
 
     public IOKXRestClientUnifiedApiShared SharedClient => this;
 
-    internal OKXRestClientUnifiedApi(ILogger logger, HttpClient? httpClient, OKXRestOptions options)
-            : base(logger, OKXExchange.Metadata.Id, httpClient, options.Environment.RestAddress, options, options.UnifiedOptions)
+    internal OKXRestClientUnifiedApi(ILoggerFactory? loggerFactory, HttpClient? httpClient, OKXRestOptions options)
+            : base(loggerFactory, OKXExchange.Metadata.Id, httpClient, options.Environment.RestAddress, options, options.UnifiedOptions)
     {
         Account = new OKXRestClientUnifiedApiAccount(this);
         ExchangeData = new OKXRestClientUnifiedApiExchangeData(this);

--- a/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiAccount.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiAccount.cs
@@ -18,35 +18,35 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
     }
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXAccountBalance>> GetAccountBalanceAsync(string? asset = null, CancellationToken ct = default)
+    public async Task<HttpResult<OKXAccountBalance>> GetAccountBalanceAsync(string? asset = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("ccy", asset);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("ccy", asset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/balance", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/balance", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(10, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXAccountBalance>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXPosition[]>> GetPositionsAsync(
+    public virtual async Task<HttpResult<OKXPosition[]>> GetPositionsAsync(
         InstrumentType? instrumentType = null,
         string? symbol = null,
         string? positionId = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalEnum("instType", instrumentType);
-        parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalParameter("posId", positionId);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("instId", symbol);
+        parameters.Add("posId", positionId);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/positions", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/positions", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(10, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXPosition[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXClosingPosition[]>> GetPositionHistoryAsync(
+    public virtual async Task<HttpResult<OKXClosingPosition[]>> GetPositionHistoryAsync(
         InstrumentType? instrumentType = null,
         string? symbol = null,
         MarginMode? marginMode = null,
@@ -57,40 +57,40 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
         int limit = 100,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalEnum("instType", instrumentType);
-        parameters.AddOptionalEnum("mgnMode", marginMode);
-        parameters.AddOptionalEnum("type", type);
-        parameters.AddOptionalParameter("posId", positionId);
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
-        parameters.AddOptionalParameter("limit", limit.ToString());
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("mgnMode", marginMode);
+        parameters.Add("type", type);
+        parameters.Add("posId", positionId);
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
+        parameters.Add("limit", limit.ToString());
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/positions-history", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/positions-history", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(10, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXClosingPosition[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXPositionRisk[]>> GetPositionRiskAsync(InstrumentType? instrumentType = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXPositionRisk[]>> GetPositionRiskAsync(InstrumentType? instrumentType = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalEnum("instType", instrumentType);
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/account-position-risk", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/account-position-risk", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(10, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXPositionRisk[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXRiskState[]>> GetAccountRiskStateAsync(CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXRiskState[]>> GetAccountRiskStateAsync(CancellationToken ct = default)
     {
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/risk-state", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/risk-state", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(10, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXRiskState[]>(request, null, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAccountBill[]>> GetBillHistoryAsync(
+    public virtual async Task<HttpResult<OKXAccountBill[]>> GetBillHistoryAsync(
         InstrumentType? instrumentType = null,
         string? asset = null,
         MarginMode? marginMode = null,
@@ -107,27 +107,27 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("ccy", asset);
-        parameters.AddOptionalParameter("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
-        parameters.AddOptionalParameter("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
-        parameters.AddOptionalParameter("after", fromId);
-        parameters.AddOptionalParameter("before", toId);
-        parameters.AddOptionalParameter("limit", limit.ToString());
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("ccy", asset);
+        parameters.Add("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
+        parameters.Add("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
+        parameters.Add("after", fromId);
+        parameters.Add("before", toId);
+        parameters.Add("limit", limit.ToString());
 
-        parameters.AddOptionalEnum("instType", instrumentType);
-        parameters.AddOptionalEnum("mgnMode", marginMode);
-        parameters.AddOptionalEnum("ctType", contractType);
-        parameters.AddOptionalEnum("type", billType);
-        parameters.AddOptionalEnum("subType", billSubType);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("mgnMode", marginMode);
+        parameters.Add("ctType", contractType);
+        parameters.Add("type", billType);
+        parameters.Add("subType", billSubType);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/bills", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/bills", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXAccountBill[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAccountBill[]>> GetBillArchiveAsync(
+    public virtual async Task<HttpResult<OKXAccountBill[]>> GetBillArchiveAsync(
         InstrumentType? instrumentType = null,
         string? asset = null,
         MarginMode? marginMode = null,
@@ -144,64 +144,64 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("ccy", asset);
-        parameters.AddOptionalParameter("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
-        parameters.AddOptionalParameter("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
-        parameters.AddOptionalParameter("after", fromId);
-        parameters.AddOptionalParameter("before", toId);
-        parameters.AddOptionalParameter("limit", limit.ToString());
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("ccy", asset);
+        parameters.Add("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
+        parameters.Add("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
+        parameters.Add("after", fromId);
+        parameters.Add("before", toId);
+        parameters.Add("limit", limit.ToString());
 
-        parameters.AddOptionalEnum("instType", instrumentType);
-        parameters.AddOptionalEnum("mgnMode", marginMode);
-        parameters.AddOptionalEnum("ctType", contractType);
-        parameters.AddOptionalEnum("type", billType);
-        parameters.AddOptionalEnum("subType", billSubType);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("mgnMode", marginMode);
+        parameters.Add("ctType", contractType);
+        parameters.Add("type", billType);
+        parameters.Add("subType", billSubType);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/bills-archive", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/bills-archive", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXAccountBill[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAccountConfiguration>> GetAccountConfigurationAsync(CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXAccountConfiguration>> GetAccountConfigurationAsync(CancellationToken ct = default)
     {
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/config", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/config", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXAccountConfiguration>(request, null, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAccountPositionMode>> SetPositionModeAsync(PositionMode positionMode, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXAccountPositionMode>> SetPositionModeAsync(PositionMode positionMode, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("posMode", positionMode);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("posMode", positionMode);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/account/set-position-mode", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/account/set-position-mode", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXAccountPositionMode>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXLeverage[]>> GetLeverageAsync(
+    public virtual async Task<HttpResult<OKXLeverage[]>> GetLeverageAsync(
         string symbols,
         MarginMode marginMode,
         string? asset = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             {"instId", symbols }
         };
-        parameters.AddEnum("mgnMode", marginMode);
-        parameters.AddOptional("ccy", asset);
+        parameters.Add("mgnMode", marginMode);
+        parameters.Add("ccy", asset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/leverage-info", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/leverage-info", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXLeverage[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXLeverage[]>> SetLeverageAsync(
+    public virtual async Task<HttpResult<OKXLeverage[]>> SetLeverageAsync(
         int leverage,
         MarginMode marginMode,
         string? asset = null,
@@ -215,37 +215,37 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
         if (string.IsNullOrEmpty(asset) && string.IsNullOrEmpty(symbol))
             throw new ArgumentException("Either instId or ccy is required; if both are passed, instId will be used by default.");
 
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             {"lever", leverage.ToString() }
         };
-        parameters.AddEnum("mgnMode", marginMode);
-        parameters.AddOptionalParameter("ccy", asset);
-        parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalEnum("posSide", positionSide);
+        parameters.Add("mgnMode", marginMode);
+        parameters.Add("ccy", asset);
+        parameters.Add("instId", symbol);
+        parameters.Add("posSide", positionSide);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/account/set-leverage", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/account/set-leverage", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXLeverage[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXEstimatedLeverageInfo[]>> GetEstimatedLeverageInfoAsync(InstrumentType instrumentType, MarginMode marginMode, int leverage, string? symbol = null, string? asset = null, PositionSide? positionSide = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXEstimatedLeverageInfo[]>> GetEstimatedLeverageInfoAsync(InstrumentType instrumentType, MarginMode marginMode, int leverage, string? symbol = null, string? asset = null, PositionSide? positionSide = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("instType", instrumentType);
-        parameters.AddEnum("mgnMode", marginMode);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("mgnMode", marginMode);
         parameters.Add("lever", leverage.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptional("instId", symbol);
-        parameters.AddOptional("ccy", asset);
-        parameters.AddOptionalEnum("posSide", positionSide);
+        parameters.Add("instId", symbol);
+        parameters.Add("ccy", asset);
+        parameters.Add("posSide", positionSide);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/adjust-leverage-info", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/adjust-leverage-info", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXEstimatedLeverageInfo[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXMaximumAmount[]>> GetMaximumAmountAsync(
+    public virtual async Task<HttpResult<OKXMaximumAmount[]>> GetMaximumAmountAsync(
         string symbol,
         TradeMode tradeMode,
         string? asset = null,
@@ -254,22 +254,22 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
         string? tradeQuoteAsset = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             {"instId", symbol }
         };
-        parameters.AddEnum("tdMode", tradeMode);
-        parameters.AddOptionalParameter("ccy", asset);
-        parameters.AddOptionalParameter("px", price?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("leverage", leverage?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("tradeQuoteCcy", tradeQuoteAsset);
+        parameters.Add("tdMode", tradeMode);
+        parameters.Add("ccy", asset);
+        parameters.Add("px", price?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("leverage", leverage?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("tradeQuoteCcy", tradeQuoteAsset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/max-size", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/max-size", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXMaximumAmount[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXMaximumAvailableAmount[]>> GetMaximumAvailableAmountAsync(
+    public virtual async Task<HttpResult<OKXMaximumAvailableAmount[]>> GetMaximumAvailableAmountAsync(
         string symbol,
         TradeMode tradeMode,
         string? asset = null,
@@ -277,21 +277,21 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
         string? tradeQuoteAsset = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             {"instId", symbol },
         };
-        parameters.AddEnum("tdMode", tradeMode);
-        parameters.AddOptionalParameter("ccy", asset);
-        parameters.AddOptionalParameter("reduceOnly", reduceOnly);
-        parameters.AddOptionalParameter("tradeQuoteCcy", tradeQuoteAsset);
+        parameters.Add("tdMode", tradeMode);
+        parameters.Add("ccy", asset);
+        parameters.Add("reduceOnly", reduceOnly);
+        parameters.Add("tradeQuoteCcy", tradeQuoteAsset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/max-avail-size", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/max-avail-size", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXMaximumAvailableAmount[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXMarginAmount[]>> SetMarginAmountAsync(
+    public virtual async Task<HttpResult<OKXMarginAmount[]>> SetMarginAmountAsync(
         string symbol,
         PositionSide positionSide,
         MarginAddReduce marginAddReduce,
@@ -300,42 +300,42 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
         bool? auto = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             {"instId", symbol },
             {"amt", amount.ToString(CultureInfo.InvariantCulture) },
         };
 
-        parameters.AddEnum("posSide", positionSide);
-        parameters.AddEnum("type", marginAddReduce);
-        parameters.AddOptionalParameter("ccy", asset);
-        parameters.AddOptionalParameter("auto", auto);
+        parameters.Add("posSide", positionSide);
+        parameters.Add("type", marginAddReduce);
+        parameters.Add("ccy", asset);
+        parameters.Add("auto", auto);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/account/position/margin-balance", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/account/position/margin-balance", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXMarginAmount[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXMaximumLoanAmount[]>> GetMaximumLoanAmountAsync(
+    public virtual async Task<HttpResult<OKXMaximumLoanAmount[]>> GetMaximumLoanAmountAsync(
         MarginMode marginMode,
         string? symbol = null,
         string? asset = null,
         string? marginAsset = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("mgnMode", marginMode);
-        parameters.AddOptionalParameter("mgnCcy", marginAsset);
-        parameters.AddOptional("instId", symbol);
-        parameters.AddOptional("ccy", asset);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("mgnMode", marginMode);
+        parameters.Add("mgnCcy", marginAsset);
+        parameters.Add("instId", symbol);
+        parameters.Add("ccy", asset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/max-loan", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/max-loan", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXMaximumLoanAmount[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXFeeRate>> GetFeeRatesAsync(
+    public virtual async Task<HttpResult<OKXFeeRate>> GetFeeRatesAsync(
         InstrumentType instrumentType,
         string? symbol = null,
         string? underlying = null,
@@ -344,21 +344,21 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
         string? groupId = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("instType", instrumentType);
-        parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalParameter("uly", underlying);
-        parameters.AddOptionalParameter("instFamily", instrumentFamily);
-        parameters.AddOptional("groupId", groupId);
-        parameters.AddOptionalEnum("ruleType", ruleType);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("instId", symbol);
+        parameters.Add("uly", underlying);
+        parameters.Add("instFamily", instrumentFamily);
+        parameters.Add("groupId", groupId);
+        parameters.Add("ruleType", ruleType);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/trade-fee", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/trade-fee", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXFeeRate>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXInterestAccrued[]>> GetInterestAccruedAsync(
+    public virtual async Task<HttpResult<OKXInterestAccrued[]>> GetInterestAccruedAsync(
         string? symbol = null,
         string? asset = null,
         MarginMode? marginMode = null,
@@ -370,91 +370,91 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalParameter("ccy", asset);
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
-        parameters.AddOptionalParameter("limit", limit.ToString());
-        parameters.AddOptionalEnum("mgnMode", marginMode);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instId", symbol);
+        parameters.Add("ccy", asset);
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
+        parameters.Add("limit", limit.ToString());
+        parameters.Add("mgnMode", marginMode);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/interest-accrued", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/interest-accrued", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXInterestAccrued[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAccountInterestRate[]>> GetInterestRateAsync(
+    public virtual async Task<HttpResult<OKXAccountInterestRate[]>> GetInterestRateAsync(
         string? asset = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("ccy", asset);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("ccy", asset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/interest-rate", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/interest-rate", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXAccountInterestRate[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXBorrowInterestLimit[]>> GetBorrowInterestLimitAsync(LoanType? type = null, string? asset = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXBorrowInterestLimit[]>> GetBorrowInterestLimitAsync(LoanType? type = null, string? asset = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalEnum("type", type);
-        parameters.AddOptional("ccy", asset);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("type", type);
+        parameters.Add("ccy", asset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/interest-limits", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/interest-limits", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXBorrowInterestLimit[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAccountGreeksType>> SetGreeksAsync(GreeksType greeksType, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXAccountGreeksType>> SetGreeksAsync(GreeksType greeksType, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("greeksType", greeksType);
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/account/set-greeks", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("greeksType", greeksType);
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/account/set-greeks", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXAccountGreeksType>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXWithdrawalAmount[]>> GetMaximumWithdrawalsAsync(
+    public virtual async Task<HttpResult<OKXWithdrawalAmount[]>> GetMaximumWithdrawalsAsync(
         string? asset = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("ccy", asset);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("ccy", asset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/max-withdrawal", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/max-withdrawal", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXWithdrawalAmount[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAsset[]>> GetAssetsAsync(string? asset = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXAsset[]>> GetAssetsAsync(string? asset = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("ccy", asset);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("ccy", asset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/asset/currencies", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/asset/currencies", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(6, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXAsset[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXFundingBalance[]>> GetFundingBalanceAsync(string? asset = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXFundingBalance[]>> GetFundingBalanceAsync(string? asset = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("ccy", asset);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("ccy", asset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/asset/balances", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/asset/balances", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(6, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXFundingBalance[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXTransferResponse>> TransferAsync(
+    public virtual async Task<HttpResult<OKXTransferResponse>> TransferAsync(
         string asset,
         decimal amount,
         TransferType type,
@@ -468,24 +468,24 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
         bool? ignorePositionRisk = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             { "ccy",asset},
             { "amt",amount.ToString(CultureInfo.InvariantCulture)},
         };
-        parameters.AddEnum("from", fromAccount);
-        parameters.AddEnum("type", type);
-        parameters.AddEnum("to", toAccount);
-        parameters.AddOptionalParameter("subAcct", subAccountName);
-        parameters.AddOptionalParameter("instId", fromSymbol);
-        parameters.AddOptionalParameter("toInstId", toSymbol);
+        parameters.Add("from", fromAccount);
+        parameters.Add("type", type);
+        parameters.Add("to", toAccount);
+        parameters.Add("subAcct", subAccountName);
+        parameters.Add("instId", fromSymbol);
+        parameters.Add("toInstId", toSymbol);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/asset/transfer", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/asset/transfer", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(2, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXTransferResponse>(request, parameters, ct, rateLimitKeySuffix: asset).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXFundingBill[]>> GetFundingBillDetailsAsync(
+    public virtual async Task<HttpResult<OKXFundingBill[]>> GetFundingBillDetailsAsync(
         string? asset = null,
         FundingBillType? type = null,
         DateTime? endTime = null,
@@ -502,24 +502,24 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
         if ((startTime != null || endTime != null) && (startBillId != null || endBillId != null))
             throw new ArgumentException("Filter can be either on start/end bill id or start/end time");
 
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("ccy", asset);
-        parameters.AddOptionalEnum("type", type);
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
-        parameters.AddOptionalString("before", endBillId);
-        parameters.AddOptionalString("after", startBillId);
-        parameters.AddOptionalParameter("limit", limit.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("clientId", clientId);
-        parameters.AddOptionalParameter("pagingType", startBillId != null || endBillId != null ? "2" : null);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("ccy", asset);
+        parameters.Add("type", type);
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
+        parameters.AddAsString("before", endBillId);
+        parameters.AddAsString("after", startBillId);
+        parameters.Add("limit", limit.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("clientId", clientId);
+        parameters.Add("pagingType", startBillId != null || endBillId != null ? "2" : null);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/asset/bills", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/asset/bills", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(6, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXFundingBill[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXFundingBill[]>> GetFundingBillHistoryAsync(
+    public virtual async Task<HttpResult<OKXFundingBill[]>> GetFundingBillHistoryAsync(
         string? asset = null,
         FundingBillType? type = null,
         DateTime? endTime = null,
@@ -536,35 +536,35 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
         if ((startTime != null || endTime != null) && (startBillId != null || endBillId != null))
             throw new ArgumentException("Filter can be either on start/end bill id or start/end time");
 
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("ccy", asset);
-        parameters.AddOptionalEnum("type", type);
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
-        parameters.AddOptionalString("before", endBillId);
-        parameters.AddOptionalString("after", startBillId);
-        parameters.AddOptionalParameter("limit", limit.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("clientId", clientId);
-        parameters.AddOptionalParameter("pagingType", startBillId != null || endBillId != null ? "2" : null);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("ccy", asset);
+        parameters.Add("type", type);
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
+        parameters.AddAsString("before", endBillId);
+        parameters.AddAsString("after", startBillId);
+        parameters.Add("limit", limit.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("clientId", clientId);
+        parameters.Add("pagingType", startBillId != null || endBillId != null ? "2" : null);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, $"api/v5/asset/bills-history", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/asset/bills-history", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(1, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXFundingBill[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXDepositAddress[]>> GetDepositAddressAsync(string? asset = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXDepositAddress[]>> GetDepositAddressAsync(string? asset = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("ccy", asset);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("ccy", asset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/asset/deposit-address", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/asset/deposit-address", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(6, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXDepositAddress[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXDepositHistory[]>> GetDepositHistoryAsync(
+    public virtual async Task<HttpResult<OKXDepositHistory[]>> GetDepositHistoryAsync(
         string? asset = null,
         string? transactionId = null,
         DepositState? state = null,
@@ -579,24 +579,24 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("ccy", asset);
-        parameters.AddOptionalParameter("txId", transactionId);
-        parameters.AddOptionalParameter("state", EnumConverter.GetString(state));
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
-        parameters.AddOptionalParameter("limit", limit.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("depId", depositId);
-        parameters.AddOptionalParameter("fromWdId", fromWithdrawalId);
-        parameters.AddOptionalParameter("type", EnumConverter.GetString(type));
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("ccy", asset);
+        parameters.Add("txId", transactionId);
+        parameters.Add("state", EnumConverter.GetString(state));
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
+        parameters.Add("limit", limit.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("depId", depositId);
+        parameters.Add("fromWdId", fromWithdrawalId);
+        parameters.Add("type", EnumConverter.GetString(type));
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/asset/deposit-history", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/asset/deposit-history", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(6, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXDepositHistory[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXWithdrawalResponse>> WithdrawAsync(
+    public virtual async Task<HttpResult<OKXWithdrawalResponse>> WithdrawAsync(
         string asset,
         decimal amount,
         WithdrawalDestination destination,
@@ -607,36 +607,36 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
         string? clientId = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             { "ccy",asset},
             { "amt",amount.ToString(CultureInfo.InvariantCulture)},
             { "toAddr",toAddress},
             { "fee",fee.ToString(CultureInfo.InvariantCulture)},
         };
-        parameters.AddEnum("dest", destination);
-        parameters.AddOptionalParameter("chain", network);
-        parameters.AddOptionalParameter("areaCode", areaCode);
-        parameters.AddOptionalParameter("clientId", clientId);
+        parameters.Add("dest", destination);
+        parameters.Add("chain", network);
+        parameters.Add("areaCode", areaCode);
+        parameters.Add("clientId", clientId);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/asset/withdrawal", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/asset/withdrawal", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(6, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXWithdrawalResponse>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXWithdrawalId>> CancelWithdrawalAsync(string withdrawalId, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXWithdrawalId>> CancelWithdrawalAsync(string withdrawalId, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             { "wdId",withdrawalId},
         };
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/asset/cancel-withdrawal", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/asset/cancel-withdrawal", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(6, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXWithdrawalId>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXWithdrawalHistory[]>> GetWithdrawalHistoryAsync(
+    public virtual async Task<HttpResult<OKXWithdrawalHistory[]>> GetWithdrawalHistoryAsync(
         string? asset = null,
         string? transactionId = null,
         WithdrawalState? state = null,
@@ -650,49 +650,49 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("ccy", asset);
-        parameters.AddOptionalParameter("txId", transactionId);
-        parameters.AddOptionalParameter("state", EnumConverter.GetString(state));
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
-        parameters.AddOptionalParameter("limit", limit.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("wdId", withdrawalId);
-        parameters.AddOptionalParameter("clientId", clientId);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("ccy", asset);
+        parameters.Add("txId", transactionId);
+        parameters.Add("state", EnumConverter.GetString(state));
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
+        parameters.Add("limit", limit.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("wdId", withdrawalId);
+        parameters.Add("clientId", clientId);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/asset/withdrawal-history", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/asset/withdrawal-history", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(6, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXWithdrawalHistory[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXSavingBalance[]>> GetSavingBalancesAsync(string? asset = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXSavingBalance[]>> GetSavingBalancesAsync(string? asset = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("ccy", asset);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("ccy", asset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/finance/savings/balance", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/finance/savings/balance", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(6, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXSavingBalance[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXSavingActionResponse>> SavingPurchaseRedemptionAsync(
+    public virtual async Task<HttpResult<OKXSavingActionResponse>> SavingPurchaseRedemptionAsync(
         string asset,
         decimal amount,
         SavingActionSide side,
         decimal? rate = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             { "ccy",asset},
             { "amt",amount.ToString(CultureInfo.InvariantCulture)},
         };
 
-        parameters.AddEnum("side", side);
-        parameters.AddOptionalParameter("rate", rate?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("side", side);
+        parameters.Add("rate", rate?.ToString(CultureInfo.InvariantCulture));
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/finance/savings/purchase-redempt", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/finance/savings/purchase-redempt", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(6, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXSavingActionResponse>(request, parameters, ct).ConfigureAwait(false);
     }
@@ -700,12 +700,12 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
     #region Get Easy Convert Dust Assets
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXDustAssets>> GetEasyConvertDustAssetsAsync(AccountType? sourceAccount = null, CancellationToken ct = default)
+    public async Task<HttpResult<OKXDustAssets>> GetEasyConvertDustAssetsAsync(AccountType? sourceAccount = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
         if (sourceAccount != null)
             parameters.Add("source", sourceAccount == AccountType.Funding ? "2" : "1");
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v5/trade/easy-convert-currency-list", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v5/trade/easy-convert-currency-list", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(1, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         var result = await _baseClient.SendGetSingleAsync<OKXDustAssets>(request, parameters, ct).ConfigureAwait(false);
         return result;
@@ -714,15 +714,15 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
     #endregion
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXDustConvertEntry[]>> EasyConvertDustAsync(IEnumerable<string> assets, string targetAsset, AccountType? sourceAccount = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXDustConvertEntry[]>> EasyConvertDustAsync(IEnumerable<string> assets, string targetAsset, AccountType? sourceAccount = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
         parameters.AddParameter("fromCcy", assets.ToArray());
         parameters.AddParameter("toCcy", targetAsset);
         if (sourceAccount != null)
             parameters.AddParameter("source", sourceAccount == AccountType.Funding ? "2" : "1");
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/trade/easy-convert", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/trade/easy-convert", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(1, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXDustConvertEntry[]>(request, parameters, ct).ConfigureAwait(false);
     }
@@ -730,13 +730,13 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
     #region Get Easy Convert Dust History
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXDustConvertEntry[]>> GetEasyConvertDustHistoryAsync(DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default)
+    public async Task<HttpResult<OKXDustConvertEntry[]>> GetEasyConvertDustHistoryAsync(DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalMillisecondsString("after", startTime);
-        parameters.AddOptionalMillisecondsString("before", endTime);
-        parameters.AddOptional("limit", limit);
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v5/trade/easy-convert-history", OKXExchange.RateLimiter.EndpointGate, 1, true);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("after", startTime);
+        parameters.Add("before", endTime);
+        parameters.Add("limit", limit);
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v5/trade/easy-convert-history", OKXExchange.RateLimiter.EndpointGate, 1, true);
         var result = await _baseClient.SendAsync<OKXDustConvertEntry[]>(request, parameters, ct).ConfigureAwait(false);
         return result;
     }
@@ -744,85 +744,85 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
     #endregion
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAccountIsolatedMarginMode>> SetIsolatedMarginModeAsync(InstrumentType instumentType, IsolatedMarginMode isolatedMarginMode, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXAccountIsolatedMarginMode>> SetIsolatedMarginModeAsync(InstrumentType instumentType, IsolatedMarginMode isolatedMarginMode, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("type", instumentType);
-        parameters.AddEnum("isoMode", isolatedMarginMode);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("type", instumentType);
+        parameters.Add("isoMode", isolatedMarginMode);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/account/set-isolated-mode", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/account/set-isolated-mode", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXAccountIsolatedMarginMode>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXTransferInfo>> GetTransferAsync(string? transferId = null, string? clientTransferId = null, TransferType? type = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXTransferInfo>> GetTransferAsync(string? transferId = null, string? clientTransferId = null, TransferType? type = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptional("transId", transferId);
-        parameters.AddOptional("clientId", clientTransferId);
-        parameters.AddOptionalEnum("type", type);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("transId", transferId);
+        parameters.Add("clientId", clientTransferId);
+        parameters.Add("type", type);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/asset/transfer-state", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/asset/transfer-state", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(1, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXTransferInfo>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXPresetAccountMode>> PresetAccountModeSwitchAsync(AccountLevel mode, int? leverage = null, RiskOffsetType? riskOffsetType = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXPresetAccountMode>> PresetAccountModeSwitchAsync(AccountLevel mode, int? leverage = null, RiskOffsetType? riskOffsetType = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("acctLv", mode);
-        parameters.AddOptionalString("lever", leverage);
-        parameters.AddOptionalEnum("riskOffsetType", riskOffsetType);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("acctLv", mode);
+        parameters.Add("lever", leverage);
+        parameters.Add("riskOffsetType", riskOffsetType);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/account/account-level-switch-preset", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/account/account-level-switch-preset", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXPresetAccountMode>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAccountSwitchCheckResult>> PrecheckAccountModeSwitchAsync(AccountLevel mode, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXAccountSwitchCheckResult>> PrecheckAccountModeSwitchAsync(AccountLevel mode, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("acctLv", mode);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("acctLv", mode);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/set-account-switch-precheck", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/set-account-switch-precheck", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXAccountSwitchCheckResult>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAccountMode>> SetAccountModeAsync(AccountLevel mode, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXAccountMode>> SetAccountModeAsync(AccountLevel mode, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("acctLv", mode);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("acctLv", mode);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/account/set-account-level", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/account/set-account-level", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXAccountMode>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXInviteeDetails>> GetAffiliateInviteeDetailsAsync(string userId, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXInviteeDetails>> GetAffiliateInviteeDetailsAsync(string userId, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "uid", userId }
         };
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/affiliate/invitee/detail", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/affiliate/invitee/detail", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(10, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXInviteeDetails>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAssetValuation>> GetAssetValuationAsync(string? asset = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXAssetValuation>> GetAssetValuationAsync(string? asset = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptional("ccy", asset);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("ccy", asset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/asset/asset-valuation", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/asset/asset-valuation", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(1, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXAssetValuation>(request, parameters, ct).ConfigureAwait(false);
     }
@@ -830,13 +830,13 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
     #region Manual Borrow Repay
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXBorrowRepayResult>> ManualBorrowRepay(string asset, BorrowRepaySide BorrowRepaySide, decimal quantity, CancellationToken ct = default)
+    public async Task<HttpResult<OKXBorrowRepayResult>> ManualBorrowRepay(string asset, BorrowRepaySide BorrowRepaySide, decimal quantity, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
         parameters.Add("ccy", asset);
-        parameters.AddEnum("side", BorrowRepaySide);
-        parameters.AddString("amt", quantity);
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v5/account/spot-manual-borrow-repay", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        parameters.Add("side", BorrowRepaySide);
+        parameters.Add("amt", quantity);
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v5/account/spot-manual-borrow-repay", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(1, TimeSpan.FromSeconds(3), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         var result = await _baseClient.SendGetSingleAsync<OKXBorrowRepayResult>(request, parameters, ct).ConfigureAwait(false);
         return result;
@@ -847,11 +847,11 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
     #region Set Auto Repay
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXAutoRepayStatus>> SetAutoRepayAsync(bool autoRepay, CancellationToken ct = default)
+    public async Task<HttpResult<OKXAutoRepayStatus>> SetAutoRepayAsync(bool autoRepay, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
         parameters.Add("autoRepay", autoRepay);
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "/api/v5/account/set-auto-repay", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "/api/v5/account/set-auto-repay", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         var result = await _baseClient.SendGetSingleAsync<OKXAutoRepayStatus>(request, parameters, ct).ConfigureAwait(false);
         return result;
@@ -862,15 +862,15 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
     #region Get Borrow Repay History
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXBorrowRepayEntry[]>> GetBorrowRepayHistoryAsync(string? asset = null, BorrowRepayType? type = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default)
+    public async Task<HttpResult<OKXBorrowRepayEntry[]>> GetBorrowRepayHistoryAsync(string? asset = null, BorrowRepayType? type = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptional("ccy", asset);
-        parameters.AddOptionalEnum("type", type);
-        parameters.AddOptionalMillisecondsString("after", startTime);
-        parameters.AddOptionalMillisecondsString("before", endTime);
-        parameters.AddOptional("limit", limit);
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v5/account/spot-borrow-repay-history", OKXExchange.RateLimiter.EndpointGate, 1, true);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("ccy", asset);
+        parameters.Add("type", type);
+        parameters.Add("after", startTime);
+        parameters.Add("before", endTime);
+        parameters.Add("limit", limit);
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v5/account/spot-borrow-repay-history", OKXExchange.RateLimiter.EndpointGate, 1, true);
         var result = await _baseClient.SendAsync<OKXBorrowRepayEntry[]>(request, parameters, ct).ConfigureAwait(false);
         return result;
     }
@@ -880,15 +880,15 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
     #region Get Symbols
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXInstrument[]>> GetSymbolsAsync(InstrumentType instrumentType, string? underlying = null, string? symbol = null, string? instrumentFamily = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXInstrument[]>> GetSymbolsAsync(InstrumentType instrumentType, string? underlying = null, string? symbol = null, string? instrumentFamily = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("instType", instrumentType);
-        parameters.AddOptionalParameter("uly", underlying);
-        parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalParameter("instFamily", instrumentFamily);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("uly", underlying);
+        parameters.Add("instId", symbol);
+        parameters.Add("instFamily", instrumentFamily);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/instruments", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/instruments", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXInstrument[]>(request, parameters, ct, rateLimitKeySuffix: instrumentType.ToString()).ConfigureAwait(false);
     }
@@ -898,12 +898,12 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
     #region Set Fee Type
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXFeeType>> SetFeeTypeAsync(FeeType feeType, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXFeeType>> SetFeeTypeAsync(FeeType feeType, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("feeType", feeType);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("feeType", feeType);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/account/set-fee-type", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/account/set-fee-type", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXFeeType>(request, parameters, ct).ConfigureAwait(false);
     }
@@ -913,12 +913,12 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
     #region Set Settle Asset
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXSettleAsset>> SetSettleAssetAsync(string settleAsset, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXSettleAsset>> SetSettleAssetAsync(string settleAsset, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
         parameters.Add("settleCcy", settleAsset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/account/set-settle-currency", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/account/set-settle-currency", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXSettleAsset>(request, parameters, ct).ConfigureAwait(false);
     }
@@ -928,12 +928,12 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
     #region Get Greeks
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXGreeks[]>> GetGreeksAsync(string? asset = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXGreeks[]>> GetGreeksAsync(string? asset = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptional("ccy", asset);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("ccy", asset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/greeks", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/greeks", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(10, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXGreeks[]>(request, parameters, ct).ConfigureAwait(false);
     }

--- a/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiAccount.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiAccount.cs
@@ -507,8 +507,8 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
         parameters.Add("type", type);
         parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
         parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
-        parameters.AddAsString("before", endBillId);
-        parameters.AddAsString("after", startBillId);
+        parameters.Add("before", endBillId, IntegerSerialization.String);
+        parameters.Add("after", startBillId, IntegerSerialization.String);
         parameters.Add("limit", limit.ToString(CultureInfo.InvariantCulture));
         parameters.Add("clientId", clientId);
         parameters.Add("pagingType", startBillId != null || endBillId != null ? "2" : null);
@@ -541,8 +541,8 @@ internal class OKXRestClientUnifiedApiAccount : IOKXRestClientUnifiedApiAccount
         parameters.Add("type", type);
         parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
         parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
-        parameters.AddAsString("before", endBillId);
-        parameters.AddAsString("after", startBillId);
+        parameters.Add("before", endBillId, IntegerSerialization.String);
+        parameters.Add("after", startBillId, IntegerSerialization.String);
         parameters.Add("limit", limit.ToString(CultureInfo.InvariantCulture));
         parameters.Add("clientId", clientId);
         parameters.Add("pagingType", startBillId != null || endBillId != null ? "2" : null);

--- a/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiCopyTrading.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiCopyTrading.cs
@@ -15,15 +15,15 @@ internal class OKXRestClientUnifiedApiCopyTrading : IOKXRestClientUnifiedApiCopy
     }
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXCopyTradingAccount>> GetAccountConfigurationAsync(CancellationToken ct = default)
+    public async Task<HttpResult<OKXCopyTradingAccount>> GetAccountConfigurationAsync(CancellationToken ct = default)
     {
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/copytrading/config", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/copytrading/config", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXCopyTradingAccount>(request, null, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXCurrentSubposition[]>> GetLeadTraderCurrentLeadPositionsAsync(string uniqueCode, string instType = "SWAP", string? after = null, string? before = null, int limit = 100, CancellationToken ct = default)
+    public async Task<HttpResult<OKXCurrentSubposition[]>> GetLeadTraderCurrentLeadPositionsAsync(string uniqueCode, string instType = "SWAP", string? after = null, string? before = null, int limit = 100, CancellationToken ct = default)
     {
         if (uniqueCode.Length != 16)
             throw new ArgumentException("uniqueCode all numbers and the length is 16 characters");
@@ -32,94 +32,94 @@ internal class OKXRestClientUnifiedApiCopyTrading : IOKXRestClientUnifiedApiCopy
         if (limit > 100)
             limit = 100;
 
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("instType", instType);
-        parameters.AddOptionalParameter("uniqueCode", uniqueCode);
-        parameters.AddOptionalParameter("after", after);
-        parameters.AddOptionalParameter("before", before);
-        parameters.AddOptionalParameter("limit", limit);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instType);
+        parameters.Add("uniqueCode", uniqueCode);
+        parameters.Add("after", after);
+        parameters.Add("before", before);
+        parameters.Add("limit", limit);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/copytrading/public-current-subpositions", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/copytrading/public-current-subpositions", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.Default));
         return await _baseClient.SendAsync<OKXCurrentSubposition[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXCurrentSubposition[]>> GetLeadPositionsAsync(string? symbol = null, InstrumentType? instrumentType = null, string? after = null, string? before = null, int limit = 500, CancellationToken ct = default)
+    public async Task<HttpResult<OKXCurrentSubposition[]>> GetLeadPositionsAsync(string? symbol = null, InstrumentType? instrumentType = null, string? after = null, string? before = null, int limit = 500, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalEnum("instType", instrumentType);
-        parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalParameter("after", after);
-        parameters.AddOptionalParameter("before", before);
-        parameters.AddOptionalParameter("limit", limit);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("instId", symbol);
+        parameters.Add("after", after);
+        parameters.Add("before", before);
+        parameters.Add("limit", limit);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/copytrading/current-subpositions", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/copytrading/current-subpositions", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXCurrentSubposition[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXSubpositionHistory[]>> GetLeadPositionHistoryAsync(string? symbol = null, InstrumentType? instrumentType = null, string? after = null, string? before = null, int limit = 100, CancellationToken ct = default)
+    public async Task<HttpResult<OKXSubpositionHistory[]>> GetLeadPositionHistoryAsync(string? symbol = null, InstrumentType? instrumentType = null, string? after = null, string? before = null, int limit = 100, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalEnum("instType", instrumentType);
-        parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalParameter("after", after);
-        parameters.AddOptionalParameter("before", before);
-        parameters.AddOptionalParameter("limit", limit);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("instId", symbol);
+        parameters.Add("after", after);
+        parameters.Add("before", before);
+        parameters.Add("limit", limit);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/copytrading/subpositions-history", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/copytrading/subpositions-history", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXSubpositionHistory[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXCopyTradingActionResponse>> PlaceLeadStopOrderAsync(string subPositionId, decimal? takeProfitTriggerPrice = null, decimal? takeProfitOrderPrice = null, decimal? stopLossTriggerPrice = null, decimal? stopLossOrderPrice = null, CancellationToken ct = default)
+    public async Task<HttpResult<OKXCopyTradingActionResponse>> PlaceLeadStopOrderAsync(string subPositionId, decimal? takeProfitTriggerPrice = null, decimal? takeProfitOrderPrice = null, decimal? stopLossTriggerPrice = null, decimal? stopLossOrderPrice = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
         parameters.AddParameter("subPosId", subPositionId);
-        parameters.AddOptionalParameter("tpTriggerPx", takeProfitTriggerPrice);
-        parameters.AddOptionalParameter("tpOrdPx", takeProfitOrderPrice);
-        parameters.AddOptionalParameter("slTriggerPx", stopLossTriggerPrice);
-        parameters.AddOptionalParameter("slOrdPx", stopLossOrderPrice);
+        parameters.Add("tpTriggerPx", takeProfitTriggerPrice);
+        parameters.Add("tpOrdPx", takeProfitOrderPrice);
+        parameters.Add("slTriggerPx", stopLossTriggerPrice);
+        parameters.Add("slOrdPx", stopLossOrderPrice);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/copytrading/algo-order", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/copytrading/algo-order", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(2, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXCopyTradingActionResponse>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXCopyTradingActionResponse>> CloseLeadPositionAsync(string subPositionId, InstrumentType? instrumentType = null, CancellationToken ct = default)
+    public async Task<HttpResult<OKXCopyTradingActionResponse>> CloseLeadPositionAsync(string subPositionId, InstrumentType? instrumentType = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
         parameters.AddParameter("subPosId", subPositionId);
-        parameters.AddOptionalEnum("instType", instrumentType);
+        parameters.Add("instType", instrumentType);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/copytrading/close-subposition", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/copytrading/close-subposition", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXCopyTradingActionResponse>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXLeadingInstrument[]>> GetLeadingInstrumentsAsync(InstrumentType? instrumentType = null, CancellationToken ct = default)
+    public async Task<HttpResult<OKXLeadingInstrument[]>> GetLeadingInstrumentsAsync(InstrumentType? instrumentType = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalEnum("instType", instrumentType);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/copytrading/instruments", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/copytrading/instruments", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXLeadingInstrument[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXLeadingInstrument[]>> AmendLeadingInstrumentsAsync(IEnumerable<string> symbols, InstrumentType? instrumentType = null, CancellationToken ct = default)
+    public async Task<HttpResult<OKXLeadingInstrument[]>> AmendLeadingInstrumentsAsync(IEnumerable<string> symbols, InstrumentType? instrumentType = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
         parameters.AddParameter("instId", string.Join(",", symbols));
-        parameters.AddOptionalEnum("instType", instrumentType);
+        parameters.Add("instType", instrumentType);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/copytrading/set-instruments", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/copytrading/set-instruments", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXLeadingInstrument[]>(request, parameters, ct).ConfigureAwait(false);
     }

--- a/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiExchangeData.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiExchangeData.cs
@@ -19,90 +19,93 @@ internal class OKXRestClientUnifiedApiExchangeData : IOKXRestClientUnifiedApiExc
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXTicker[]>> GetTickersAsync(InstrumentType instrumentType, string? underlying = null, string? instrumentFamily = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXTicker[]>> GetTickersAsync(InstrumentType instrumentType, string? underlying = null, string? instrumentFamily = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("instType", instrumentType);
-        parameters.AddOptionalParameter("uly", underlying);
-        parameters.AddOptionalParameter("instFamily", instrumentFamily);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("uly", underlying);
+        parameters.Add("instFamily", instrumentFamily);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/market/tickers", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/market/tickers", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXTicker[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXTicker>> GetTickerAsync(string symbol, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXTicker>> GetTickerAsync(string symbol, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "instId", symbol },
         };
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/market/ticker", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/market/ticker", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         var result = await _baseClient.SendAsync<OKXTicker[]>(request, parameters, ct).ConfigureAwait(false);
-        return result.As<OKXTicker>(result.Data?.FirstOrDefault());
+        if (!result.Success)
+            return HttpResult.Fail<OKXTicker>(result);
+
+        return HttpResult.Ok(result, result.Data.First());
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXIndexTicker[]>> GetIndexTickersAsync(string? quoteAsset = null, string? symbol = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXIndexTicker[]>> GetIndexTickersAsync(string? quoteAsset = null, string? symbol = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("quoteCcy", quoteAsset);
-        parameters.AddOptionalParameter("instId", symbol);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("quoteCcy", quoteAsset);
+        parameters.Add("instId", symbol);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/market/index-tickers", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/market/index-tickers", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXIndexTicker[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXOrderBook>> GetOrderBookAsync(string symbol, int depth = 1, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXOrderBook>> GetOrderBookAsync(string symbol, int depth = 1, CancellationToken ct = default)
     {
         if (depth < 1 || depth > 400)
             throw new ArgumentException("Depth can be between 1-400.");
 
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             {"instId", symbol},
             {"sz", depth},
         };
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/market/books", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/market/books", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(40, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         var result = await _baseClient.SendAsync<OKXOrderBook[]>(request, parameters, ct).ConfigureAwait(false);
-        if (!result)
-            return result.As<OKXOrderBook>(default);
+        if (!result.Success)
+            return HttpResult.Fail<OKXOrderBook>(result);
 
         if (!result.Data.Any())
-            return result.AsError<OKXOrderBook>(new ServerError(new ErrorInfo(ErrorType.Unknown, "No data")));
+            return HttpResult.Fail<OKXOrderBook>(result, new ServerError(new ErrorInfo(ErrorType.Unknown, "No data")));
 
         var orderbook = result.Data.First();
         orderbook.Symbol = symbol;
-        return result.As(orderbook);
+        return HttpResult.Ok(result, orderbook);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXKline[]>> GetKlinesAsync(string symbol, KlineInterval klineInterval, DateTime? startTime = null,
+    public virtual async Task<HttpResult<OKXKline[]>> GetKlinesAsync(string symbol, KlineInterval klineInterval, DateTime? startTime = null,
         DateTime? endTime = null, int limit = 100, CancellationToken ct = default)
     {
         if (limit < 1 || limit > 300)
             throw new ArgumentException("Limit can be between 1-300.");
 
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "instId", symbol },
         };
-        parameters.AddEnum("bar", klineInterval);
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("limit", limit.ToString());
+        parameters.Add("bar", klineInterval);
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("limit", limit.ToString());
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/market/candles", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/market/candles", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(40, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         var result = await _baseClient.SendAsync<OKXKline[]>(request, parameters, ct).ConfigureAwait(false);
-        if (!result)
+        if (!result.Success)
             return result;
 
         foreach (var candle in result.Data)
@@ -111,25 +114,25 @@ internal class OKXRestClientUnifiedApiExchangeData : IOKXRestClientUnifiedApiExc
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXKline[]>> GetKlineHistoryAsync(string symbol, KlineInterval klineInterval, DateTime? startTime = null,
+    public virtual async Task<HttpResult<OKXKline[]>> GetKlineHistoryAsync(string symbol, KlineInterval klineInterval, DateTime? startTime = null,
         DateTime? endTime = null, int limit = 100, CancellationToken ct = default)
     {
         if (limit < 1 || limit > 300)
             throw new ArgumentException("Limit can be between 1-300.");
 
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "instId", symbol }
         };
-        parameters.AddEnum("bar", klineInterval);
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("limit", limit.ToString());
+        parameters.Add("bar", klineInterval);
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("limit", limit.ToString());
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/market/history-candles", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/market/history-candles", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         var result = await _baseClient.SendAsync<OKXKline[]>(request, parameters, ct).ConfigureAwait(false);
-        if (!result)
+        if (!result.Success)
             return result;
 
         foreach (var candle in result.Data)
@@ -139,25 +142,25 @@ internal class OKXRestClientUnifiedApiExchangeData : IOKXRestClientUnifiedApiExc
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXKline[]>> GetIndexKlinesAsync(string symbol, KlineInterval klineInterval, DateTime? startTime = null,
+    public virtual async Task<HttpResult<OKXKline[]>> GetIndexKlinesAsync(string symbol, KlineInterval klineInterval, DateTime? startTime = null,
         DateTime? endTime = null, int limit = 100, CancellationToken ct = default)
     {
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "instId", symbol }
         };
-        parameters.AddEnum("bar", klineInterval);
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("limit", limit.ToString());
+        parameters.Add("bar", klineInterval);
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("limit", limit.ToString());
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/market/index-candles", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/market/index-candles", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         var result = await _baseClient.SendAsync<OKXKline[]>(request, parameters, ct).ConfigureAwait(false);
-        if (!result)
+        if (!result.Success)
             return result;
 
         foreach (var candle in result.Data)
@@ -167,26 +170,26 @@ internal class OKXRestClientUnifiedApiExchangeData : IOKXRestClientUnifiedApiExc
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXKline[]>> GetMarkPriceKlinesAsync(string symbol, KlineInterval klineInterval,
+    public virtual async Task<HttpResult<OKXKline[]>> GetMarkPriceKlinesAsync(string symbol, KlineInterval klineInterval,
         DateTime? startTime = null,
         DateTime? endTime = null, int limit = 100, CancellationToken ct = default)
     {
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "instId", symbol }
         };
-        parameters.AddEnum("bar", klineInterval);
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("limit", limit.ToString());
+        parameters.Add("bar", klineInterval);
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("limit", limit.ToString());
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/market/mark-price-candles", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/market/mark-price-candles", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         var result = await _baseClient.SendAsync<OKXKline[]>(request, parameters, ct).ConfigureAwait(false);
-        if (!result)
+        if (!result.Success)
             return result;
 
         foreach (var candle in result.Data)
@@ -196,121 +199,121 @@ internal class OKXRestClientUnifiedApiExchangeData : IOKXRestClientUnifiedApiExc
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXTrade[]>> GetRecentTradesAsync(string symbol, int limit = 100, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXTrade[]>> GetRecentTradesAsync(string symbol, int limit = 100, CancellationToken ct = default)
     {
         if (limit < 1 || limit > 500)
             throw new ArgumentException("Limit can be between 1-500.");
 
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "instId", symbol },
         };
-        parameters.AddOptionalParameter("limit", limit.ToString());
+        parameters.Add("limit", limit.ToString());
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/market/trades", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/market/trades", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(100, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXTrade[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXTrade[]>> GetTradeHistoryAsync(string symbol, TradeHistoryPaginationType type = TradeHistoryPaginationType.TradeId,
+    public virtual async Task<HttpResult<OKXTrade[]>> GetTradeHistoryAsync(string symbol, TradeHistoryPaginationType type = TradeHistoryPaginationType.TradeId,
         DateTime? startTime = null,
         DateTime? endTime = null, int limit = 100, CancellationToken ct = default)
     {
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "instId", symbol },
         };
 
-        parameters.AddEnum("type", type);
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("limit", limit.ToString());
+        parameters.Add("type", type);
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("limit", limit.ToString());
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/market/history-trades", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/market/history-trades", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXTrade[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKX24HourVolume>> Get24HourVolumeAsync(CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKX24HourVolume>> Get24HourVolumeAsync(CancellationToken ct = default)
     {
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/market/platform-24-volume", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/market/platform-24-volume", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(2, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendGetSingleAsync<OKX24HourVolume>(request, null, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXIndexComponents>> GetIndexComponentsAsync(string index, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXIndexComponents>> GetIndexComponentsAsync(string index, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "index", index },
         };
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/market/index-components", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/market/index-components", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXIndexComponents>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXBlockTicker[]>> GetBlockTickersAsync(InstrumentType instrumentType, string? underlying = null, string? instrumentFamily = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXBlockTicker[]>> GetBlockTickersAsync(InstrumentType instrumentType, string? underlying = null, string? instrumentFamily = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("instType", instrumentType);
-        parameters.AddOptionalParameter("uly", underlying);
-        parameters.AddOptionalParameter("instFamily", instrumentFamily);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("uly", underlying);
+        parameters.Add("instFamily", instrumentFamily);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/market/block-tickers", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/market/block-tickers", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXBlockTicker[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXBlockTicker>> GetBlockTickerAsync(string symbol, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXBlockTicker>> GetBlockTickerAsync(string symbol, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "instId", symbol },
         };
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/market/block-ticker", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/market/block-ticker", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendGetSingleAsync<OKXBlockTicker>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXBlockTrade[]>> GetBlockTradesAsync(string symbol, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXBlockTrade[]>> GetBlockTradesAsync(string symbol, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "instId", symbol },
         };
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/public/block-trades", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/public/block-trades", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXBlockTrade[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXInstrument[]>> GetSymbolsAsync(InstrumentType instrumentType, string? underlying = null, string? symbol = null, string? instrumentFamily = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXInstrument[]>> GetSymbolsAsync(InstrumentType instrumentType, string? underlying = null, string? symbol = null, string? instrumentFamily = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("instType", instrumentType);
-        parameters.AddOptionalParameter("uly", underlying);
-        parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalParameter("instFamily", instrumentFamily);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("uly", underlying);
+        parameters.Add("instId", symbol);
+        parameters.Add("instFamily", instrumentFamily);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/public/instruments", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/public/instruments", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXInstrument[]>(request, parameters, ct, rateLimitKeySuffix: instrumentType.ToString()).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXDeliveryExerciseHistory[]>> GetDeliveryExerciseHistoryAsync(
+    public virtual async Task<HttpResult<OKXDeliveryExerciseHistory[]>> GetDeliveryExerciseHistoryAsync(
         InstrumentType instrumentType,
         string? underlying = null,
         DateTime? startTime = null,
@@ -325,154 +328,157 @@ internal class OKXRestClientUnifiedApiExchangeData : IOKXRestClientUnifiedApiExc
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("instType", instrumentType);
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("limit", limit.ToString());
-        parameters.AddOptionalParameter("uly", underlying);
-        parameters.AddOptionalParameter("instFamily", instrumentFamily);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("limit", limit.ToString());
+        parameters.Add("uly", underlying);
+        parameters.Add("instFamily", instrumentFamily);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/public/delivery-exercise-history", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/public/delivery-exercise-history", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(40, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXDeliveryExerciseHistory[]>(request, parameters, ct, rateLimitKeySuffix: instrumentType + underlying).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXOpenInterest[]>> GetOpenInterestsAsync(InstrumentType instrumentType, string? underlying = null, string? symbol = null, string? instrumentFamily = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXOpenInterest[]>> GetOpenInterestsAsync(InstrumentType instrumentType, string? underlying = null, string? symbol = null, string? instrumentFamily = null, CancellationToken ct = default)
     {
         if (instrumentType.IsNotIn(InstrumentType.Futures, InstrumentType.Option, InstrumentType.Swap))
             throw new ArgumentException("Instrument Type can be only Futures, Option or Swap.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("instType", instrumentType);
-        parameters.AddOptionalParameter("uly", underlying);
-        parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalParameter("instFamily", instrumentFamily);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("uly", underlying);
+        parameters.Add("instId", symbol);
+        parameters.Add("instFamily", instrumentFamily);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/public/open-interest", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/public/open-interest", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXOpenInterest[]>(request, parameters, ct, rateLimitKeySuffix: symbol).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXFundingRate[]>> GetFundingRatesAsync(string? symbol = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXFundingRate[]>> GetFundingRatesAsync(string? symbol = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "instId", symbol ?? "ANY" },
         };
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/public/funding-rate", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/public/funding-rate", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXFundingRate[]>(request, parameters, ct, rateLimitKeySuffix: symbol).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXFundingRateHistory[]>> GetFundingRateHistoryAsync(string symbol,
+    public virtual async Task<HttpResult<OKXFundingRateHistory[]>> GetFundingRateHistoryAsync(string symbol,
         DateTime? startTime = null,
         DateTime? endTime = null, int limit = 100, CancellationToken ct = default)
     {
         if (limit < 1 || limit > 400)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "instId", symbol },
         };
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("limit", limit.ToString());
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("limit", limit.ToString());
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/public/funding-rate-history", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/public/funding-rate-history", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(10, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXFundingRateHistory[]>(request, parameters, ct, rateLimitKeySuffix: symbol).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXLimitPrice>> GetPriceLimitsAsync(string symbol, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXLimitPrice>> GetPriceLimitsAsync(string symbol, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "instId", symbol },
         };
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/public/price-limit", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/public/price-limit", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendGetSingleAsync<OKXLimitPrice>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXOptionSummary[]>> GetOptionMarketDataAsync(string underlying, DateTime? expiryDate = null, string? instrumentFamily = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXOptionSummary[]>> GetOptionMarketDataAsync(string underlying, DateTime? expiryDate = null, string? instrumentFamily = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "uly", underlying },
         };
-        parameters.AddOptionalParameter("expTime", expiryDate?.ToString("yyMMdd"));
-        parameters.AddOptionalParameter("instFamily", instrumentFamily);
+        parameters.Add("expTime", expiryDate?.ToString("yyMMdd"));
+        parameters.Add("instFamily", instrumentFamily);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/public/opt-summary", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/public/opt-summary", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXOptionSummary[]>(request, parameters, ct, rateLimitKeySuffix: underlying).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXEstimatedPrice>> GetEstimatedPriceAsync(string symbol, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXEstimatedPrice>> GetEstimatedPriceAsync(string symbol, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "instId", symbol },
         };
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/public/estimated-price", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/public/estimated-price", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(10, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendGetSingleAsync<OKXEstimatedPrice>(request, parameters, ct, rateLimitKeySuffix: symbol).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXDiscountInfo[]>> GetDiscountInfoAsync(int? discountLevel = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXDiscountInfo[]>> GetDiscountInfoAsync(int? discountLevel = null, CancellationToken ct = default)
     {
 
         if (discountLevel.HasValue && (discountLevel < 1 || discountLevel > 5))
             throw new ArgumentException("Limit can be between 1-5.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("discountLv", discountLevel?.ToString());
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("discountLv", discountLevel?.ToString());
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/public/discount-rate-interest-free-quota", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/public/discount-rate-interest-free-quota", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(2, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXDiscountInfo[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default)
+    public virtual async Task<HttpResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default)
     {
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/public/time", OKXExchange.RateLimiter.EndpointGate, 1, false, preventCaching: true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/public/time", OKXExchange.RateLimiter.EndpointGate, 1, false, preventCaching: true,
             limitGuard: new SingleLimitGuard(10, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         var result = await _baseClient.SendGetSingleAsync<OKXTime>(request, null, ct).ConfigureAwait(false);
-        return result.As(result.Data?.Time ?? default);
+        if (!result.Success)
+            return HttpResult.Fail<DateTime>(result);
+
+        return HttpResult.Ok(result, result.Data.Time);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXMarkPrice[]>> GetMarkPricesAsync(InstrumentType instrumentType, string? underlying = null, string? symbol = null, string? instrumentFamily = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXMarkPrice[]>> GetMarkPricesAsync(InstrumentType instrumentType, string? underlying = null, string? symbol = null, string? instrumentFamily = null, CancellationToken ct = default)
     {
         if (instrumentType.IsNotIn(InstrumentType.Margin, InstrumentType.Futures, InstrumentType.Option, InstrumentType.Swap))
             throw new ArgumentException("Instrument Type can be only Margin, Futures, Option or Swap.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("instType", instrumentType);
-        parameters.AddOptionalParameter("uly", underlying);
-        parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalParameter("instFamily", instrumentFamily);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("uly", underlying);
+        parameters.Add("instId", symbol);
+        parameters.Add("instFamily", instrumentFamily);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/public/mark-price", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/public/mark-price", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(10, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXMarkPrice[]>(request, parameters, ct, rateLimitKeySuffix: symbol).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXPositionTier[]>> GetPositionTiersAsync(
+    public virtual async Task<HttpResult<OKXPositionTier[]>> GetPositionTiersAsync(
         InstrumentType instrumentType,
         MarginMode marginMode,
         string underlying,
@@ -485,43 +491,43 @@ internal class OKXRestClientUnifiedApiExchangeData : IOKXRestClientUnifiedApiExc
         if (instrumentType.IsNotIn(InstrumentType.Margin, InstrumentType.Futures, InstrumentType.Option, InstrumentType.Swap))
             throw new ArgumentException("Instrument Type can be only Margin, Futures, Option or Swap.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("instType", instrumentType);
-        parameters.AddEnum("tdMode", marginMode);
-        parameters.AddOptionalParameter("uly", underlying);
-        parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalParameter("tier", tier);
-        parameters.AddOptionalParameter("ccy", asset);
-        parameters.AddOptionalParameter("instFamily", instrumentFamily);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("tdMode", marginMode);
+        parameters.Add("uly", underlying);
+        parameters.Add("instId", symbol);
+        parameters.Add("tier", tier);
+        parameters.Add("ccy", asset);
+        parameters.Add("instFamily", instrumentFamily);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/public/position-tiers", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/public/position-tiers", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(10, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXPositionTier[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXInterestRate>> GetInterestRatesAsync(CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXInterestRate>> GetInterestRatesAsync(CancellationToken ct = default)
     {
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/public/interest-rate-loan-quota", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/public/interest-rate-loan-quota", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(2, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendGetSingleAsync<OKXInterestRate>(request, null, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<string[]>> GetUnderlyingAsync(InstrumentType instrumentType, CancellationToken ct = default)
+    public virtual async Task<HttpResult<string[]>> GetUnderlyingAsync(InstrumentType instrumentType, CancellationToken ct = default)
     {
         if (instrumentType.IsNotIn(InstrumentType.Futures, InstrumentType.Option, InstrumentType.Swap))
             throw new ArgumentException("Instrument Type can be only Futures, Option or Swap.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("instType", instrumentType);
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/public/underlying", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/public/underlying", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendGetSingleAsync<string[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXInsuranceFund>> GetInsuranceFundAsync(
+    public virtual async Task<HttpResult<OKXInsuranceFund>> GetInsuranceFundAsync(
         InstrumentType instrumentType,
         InsuranceType type = InsuranceType.All,
         string? underlying = null,
@@ -535,25 +541,25 @@ internal class OKXRestClientUnifiedApiExchangeData : IOKXRestClientUnifiedApiExc
         if (instrumentType.IsNotIn(InstrumentType.Margin, InstrumentType.Swap, InstrumentType.Futures, InstrumentType.Option))
             throw new ArgumentException("Instrument Type can be only Margin, Swap, Futures or Option.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("instType", instrumentType);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
 
         if (type != InsuranceType.All)
-            parameters.AddEnum("type", type);
-        parameters.AddOptionalParameter("uly", underlying);
-        parameters.AddOptionalParameter("ccy", asset);
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("limit", limit.ToString());
-        parameters.AddOptionalParameter("instFamily", instrumentFamily);
+            parameters.Add("type", type);
+        parameters.Add("uly", underlying);
+        parameters.Add("ccy", asset);
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("limit", limit.ToString());
+        parameters.Add("instFamily", instrumentFamily);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/public/insurance-fund", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/public/insurance-fund", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(10, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendGetSingleAsync<OKXInsuranceFund>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXUnitConvert>> UnitConvertAsync(
+    public virtual async Task<HttpResult<OKXUnitConvert>> UnitConvertAsync(
         ConvertType type,
         string symbol,
         decimal quantity,
@@ -561,28 +567,28 @@ internal class OKXRestClientUnifiedApiExchangeData : IOKXRestClientUnifiedApiExc
         decimal? price = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("type", type);
-        parameters.AddOptionalEnum("unit", unit);
-        if (!string.IsNullOrEmpty(symbol)) parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalParameter("px", price?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("sz", quantity.ToString(CultureInfo.InvariantCulture));
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("type", type);
+        parameters.Add("unit", unit);
+        if (!string.IsNullOrEmpty(symbol)) parameters.Add("instId", symbol);
+        parameters.Add("px", price?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("sz", quantity.ToString(CultureInfo.InvariantCulture));
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/public/convert-contract-coin", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/public/convert-contract-coin", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(10, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendGetSingleAsync<OKXUnitConvert>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXSupportCoins>> GetTradeStatsSupportedAssetsAsync(CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXSupportCoins>> GetTradeStatsSupportedAssetsAsync(CancellationToken ct = default)
     {
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/rubik/stat/trading-data/support-coin", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/rubik/stat/trading-data/support-coin", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXSupportCoins>(request, null, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXTakerVolume[]>> GetTradeStatsTakerVolumeAsync(
+    public virtual async Task<HttpResult<OKXTakerVolume[]>> GetTradeStatsTakerVolumeAsync(
         string asset,
         InstrumentType instrumentType,
         KlineInterval period = KlineInterval.FiveMinutes,
@@ -590,157 +596,157 @@ internal class OKXRestClientUnifiedApiExchangeData : IOKXRestClientUnifiedApiExc
         DateTime? endTime = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             { "ccy", asset}
         };
-        parameters.AddEnum("instType", instrumentType);
-        parameters.AddEnum("period", period);
-        parameters.AddOptionalParameter("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("instType", instrumentType);
+        parameters.Add("period", period);
+        parameters.Add("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/rubik/stat/taker-volume", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/rubik/stat/taker-volume", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXTakerVolume[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXRatio[]>> GetTradeStatsMarginLendingRatioAsync(
+    public virtual async Task<HttpResult<OKXRatio[]>> GetTradeStatsMarginLendingRatioAsync(
         string asset,
         KlineInterval period = KlineInterval.FiveMinutes,
         DateTime? startTime = null,
         DateTime? endTime = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             { "ccy", asset},
         };
-        parameters.AddEnum("period", period);
-        parameters.AddOptionalParameter("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("period", period);
+        parameters.Add("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/rubik/stat/margin/loan-ratio", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/rubik/stat/margin/loan-ratio", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXRatio[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXRatio[]>> GetTradeStatsLongShortRatioAsync(
+    public virtual async Task<HttpResult<OKXRatio[]>> GetTradeStatsLongShortRatioAsync(
         string asset,
         KlineInterval period = KlineInterval.FiveMinutes,
         DateTime? startTime = null,
         DateTime? endTime = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             { "ccy", asset},
         };
-        parameters.AddEnum("period", period);
-        parameters.AddOptionalParameter("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("period", period);
+        parameters.Add("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/rubik/stat/contracts/long-short-account-ratio", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/rubik/stat/contracts/long-short-account-ratio", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXRatio[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXInterestVolume[]>> GetTradeStatsContractSummaryAsync(
+    public virtual async Task<HttpResult<OKXInterestVolume[]>> GetTradeStatsContractSummaryAsync(
         string asset,
         KlineInterval period = KlineInterval.FiveMinutes,
         DateTime? startTime = null,
         DateTime? endTime = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             { "ccy", asset},
         };
-        parameters.AddEnum("period", period);
-        parameters.AddOptionalParameter("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("period", period);
+        parameters.Add("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/rubik/stat/contracts/open-interest-volume", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/rubik/stat/contracts/open-interest-volume", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXInterestVolume[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXInterestVolume[]>> GetTradeStatsOptionsSummaryAsync(
+    public virtual async Task<HttpResult<OKXInterestVolume[]>> GetTradeStatsOptionsSummaryAsync(
         string asset,
         KlineInterval period = KlineInterval.FiveMinutes,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             { "ccy", asset},
         };
-        parameters.AddEnum("period", period);
+        parameters.Add("period", period);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/rubik/stat/option/open-interest-volume", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/rubik/stat/option/open-interest-volume", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXInterestVolume[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXPutCallRatio[]>> GetTradeStatsPutCallRatioAsync(
+    public virtual async Task<HttpResult<OKXPutCallRatio[]>> GetTradeStatsPutCallRatioAsync(
         string asset,
         KlineInterval period = KlineInterval.FiveMinutes,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             { "ccy", asset},
         };
-        parameters.AddEnum("period", period);
+        parameters.Add("period", period);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/rubik/stat/option/open-interest-volume-ratio", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/rubik/stat/option/open-interest-volume-ratio", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXPutCallRatio[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXInterestVolumeExpiry[]>> GetTradeStatsInterestVolumeExpiryAsync(
+    public virtual async Task<HttpResult<OKXInterestVolumeExpiry[]>> GetTradeStatsInterestVolumeExpiryAsync(
         string asset,
         KlineInterval period = KlineInterval.FiveMinutes,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             { "ccy", asset},
         };
-        parameters.AddEnum("period", period);
+        parameters.Add("period", period);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/rubik/stat/option/open-interest-volume-expiry", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/rubik/stat/option/open-interest-volume-expiry", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXInterestVolumeExpiry[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXInterestVolumeStrike[]>> GetTradeStatsInterestVolumeStrikeAsync(
+    public virtual async Task<HttpResult<OKXInterestVolumeStrike[]>> GetTradeStatsInterestVolumeStrikeAsync(
         string asset,
         string expiryTime,
         KlineInterval period = KlineInterval.FiveMinutes,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             { "ccy", asset},
             { "expTime", expiryTime},
         };
-        parameters.AddEnum("period", period);
+        parameters.Add("period", period);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/rubik/stat/option/open-interest-volume-strike", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/rubik/stat/option/open-interest-volume-strike", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXInterestVolumeStrike[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXTakerFlow>> GetTradeStatsTakerFlowAsync(
+    public virtual async Task<HttpResult<OKXTakerFlow>> GetTradeStatsTakerFlowAsync(
         string asset,
         KlineInterval period = KlineInterval.FiveMinutes,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             { "ccy", asset},
         };
-        parameters.AddEnum("period", period);
+        parameters.Add("period", period);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/rubik/stat/option/taker-block-volume", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/rubik/stat/option/taker-block-volume", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         return await _baseClient.SendAsync<OKXTakerFlow>(request, parameters, ct).ConfigureAwait(false);
     }
@@ -748,12 +754,12 @@ internal class OKXRestClientUnifiedApiExchangeData : IOKXRestClientUnifiedApiExc
     #region Get Announcements
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXAnnouncementsPage>> GetAnnouncementsAsync(string? announcementType = null, int? page = null, CancellationToken ct = default)
+    public async Task<HttpResult<OKXAnnouncementsPage>> GetAnnouncementsAsync(string? announcementType = null, int? page = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptional("annType", announcementType);
-        parameters.AddOptional("page", page);
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v5/support/announcements", OKXExchange.RateLimiter.EndpointGate, 1, _baseClient.AuthenticationProvider != null,
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("annType", announcementType);
+        parameters.Add("page", page);
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v5/support/announcements", OKXExchange.RateLimiter.EndpointGate, 1, _baseClient.AuthenticationProvider != null,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         var result = await _baseClient.SendGetSingleAsync<OKXAnnouncementsPage>(request, parameters, ct).ConfigureAwait(false);
         return result;
@@ -764,10 +770,10 @@ internal class OKXRestClientUnifiedApiExchangeData : IOKXRestClientUnifiedApiExc
     #region Get Announcement Types
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXAnnouncementType[]>> GetAnnouncementTypesAsync(CancellationToken ct = default)
+    public async Task<HttpResult<OKXAnnouncementType[]>> GetAnnouncementTypesAsync(CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v5/support/announcement-types", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v5/support/announcement-types", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(1, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         var result = await _baseClient.SendAsync<OKXAnnouncementType[]>(request, parameters, ct).ConfigureAwait(false);
         return result;
@@ -778,11 +784,11 @@ internal class OKXRestClientUnifiedApiExchangeData : IOKXRestClientUnifiedApiExc
     #region Get Estimated Futures Settlement Price
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXSettlementPrice>> GetEstimatedFuturesSettlementPriceAsync(string symbol, CancellationToken ct = default)
+    public async Task<HttpResult<OKXSettlementPrice>> GetEstimatedFuturesSettlementPriceAsync(string symbol, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
         parameters.Add("instId", symbol);
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v5/public/estimated-settlement-info", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v5/public/estimated-settlement-info", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         var result = await _baseClient.SendGetSingleAsync<OKXSettlementPrice>(request, parameters, ct).ConfigureAwait(false);
         return result;
@@ -793,14 +799,14 @@ internal class OKXRestClientUnifiedApiExchangeData : IOKXRestClientUnifiedApiExc
     #region Get Estimated Futures Settlement Price
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXSettlementInfo[]>> GetSettlementHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default)
+    public async Task<HttpResult<OKXSettlementInfo[]>> GetSettlementHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
         parameters.Add("instId", symbol);
-        parameters.AddOptionalMillisecondsString("after", startTime);
-        parameters.AddOptionalMillisecondsString("before", endTime);
-        parameters.AddOptional("limit", limit);
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v5/public/settlement-history", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        parameters.Add("after", startTime);
+        parameters.Add("before", endTime);
+        parameters.Add("limit", limit);
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v5/public/settlement-history", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         var result = await _baseClient.SendAsync<OKXSettlementInfo[]>(request, parameters, ct).ConfigureAwait(false);
         return result;
@@ -811,13 +817,13 @@ internal class OKXRestClientUnifiedApiExchangeData : IOKXRestClientUnifiedApiExc
     #region Get Premium History
 
     /// <inheritdoc />
-    public async Task<WebCallResult<OKXPremiumHistory[]>> GetPremiumHistoryAsync(string instrumentId, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default)
+    public async Task<HttpResult<OKXPremiumHistory[]>> GetPremiumHistoryAsync(string instrumentId, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection { { "instId", instrumentId } };
-        parameters.AddOptionalMillisecondsString("after", startTime);
-        parameters.AddOptionalMillisecondsString("before", endTime);
-        parameters.AddOptional("limit", limit);
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v5/public/premium-history", OKXExchange.RateLimiter.EndpointGate, 1, false,
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) { { "instId", instrumentId } };
+        parameters.Add("after", startTime);
+        parameters.Add("before", endTime);
+        parameters.Add("limit", limit);
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v5/public/premium-history", OKXExchange.RateLimiter.EndpointGate, 1, false,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding));
         var result = await _baseClient.SendAsync<OKXPremiumHistory[]>(request, parameters, ct).ConfigureAwait(false);
         return result;

--- a/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiShared.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiShared.cs
@@ -2,6 +2,7 @@ using CryptoExchange.Net.Objects.Errors;
 using CryptoExchange.Net.SharedApis;
 using OKX.Net.Enums;
 using OKX.Net.Interfaces.Clients.UnifiedApi;
+using OKX.Net.Objects.Funding;
 using OKX.Net.Objects.Market;
 using OKX.Net.Objects.Public;
 using OKX.Net.Objects.Trade;
@@ -787,7 +788,13 @@ namespace OKX.Net.Clients.UnifiedApi
 
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
                 .Select(x =>
-                    new SharedWithdrawal(x.Asset, x.To, x.Quantity, x.State == WithdrawalState.Success, x.Time)
+                    new SharedWithdrawal(
+                        x.Asset,
+                        x.To,
+                        x.Quantity, 
+                        x.State == WithdrawalState.Success, 
+                        x.Time,
+                        GetWithdrawalStatus(x))
                     {
                         Network = x.Network,
                         TransactionId = x.TransactionId,
@@ -796,6 +803,30 @@ namespace OKX.Net.Clients.UnifiedApi
                 .ToArray(), nextPageRequest);
         }
 
+        private SharedTransferStatus GetWithdrawalStatus(OKXWithdrawalHistory x)
+        {
+            if (x.State == WithdrawalState.Canceled
+                || x.State == WithdrawalState.Failed
+                || x.State == WithdrawalState.InsufficientHotWalletBalance)
+            {
+                return SharedTransferStatus.Failed;
+            }
+
+            if (x.State == WithdrawalState.Success)
+                return SharedTransferStatus.Completed;
+
+            if (x.State == WithdrawalState.Approved
+                || x.State == WithdrawalState.AwaitingManualReview
+                || x.State == WithdrawalState.AwaitingTransfer
+                || x.State == WithdrawalState.Canceling
+                || x.State == WithdrawalState.Pending
+                || x.State == WithdrawalState.PendingTransactionValidation
+                || x.State == WithdrawalState.PendingTravelRule
+                || x.State == WithdrawalState.Withdrawing)
+                return SharedTransferStatus.InProgress;
+
+            return SharedTransferStatus.Unknown;
+        }
         #endregion
 
         #region Withdraw client

--- a/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiShared.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiShared.cs
@@ -280,7 +280,12 @@ namespace OKX.Net.Clients.UnifiedApi
                 if (!result.Success)
                     return HttpResult.Fail<SharedBalance[]>(result);
 
-                return HttpResult.Ok(result, result.Data.Details.Select(x => new SharedBalance(x.Asset, x.AvailableBalance ?? 0, x.Equity ?? 0)).ToArray());
+                return HttpResult.Ok(result, result.Data.Details.Select(x => 
+                    new SharedBalance(
+                        SupportedTradingModes, 
+                        x.Asset, 
+                        x.AvailableBalance ?? 0, 
+                        x.Equity ?? 0)).ToArray());
             }
             else
             {
@@ -288,7 +293,12 @@ namespace OKX.Net.Clients.UnifiedApi
                 if (!result.Success)
                     return HttpResult.Fail<SharedBalance[]>(result);
 
-                return HttpResult.Ok(result, result.Data.Select(x => new SharedBalance(x.Asset, x.Available, x.Balance)).ToArray());
+                return HttpResult.Ok(result, result.Data.Select(x => 
+                    new SharedBalance(
+                        [], 
+                        x.Asset,
+                        x.Available,
+                        x.Balance)).ToArray());
             }
         }
 

--- a/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiShared.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiShared.cs
@@ -803,7 +803,7 @@ namespace OKX.Net.Clients.UnifiedApi
         WithdrawOptions IWithdrawRestClient.WithdrawOptions { get; } = new WithdrawOptions(_exchangeName) {
             RequiredExchangeParameters = new List<ParameterDescription>
             {
-                new ParameterDescription("withdrawFee", typeof(decimal), "Fee to use for the withdrawal", 0.001m)
+                new ParameterDescription(["withdrawFee", "fee"], typeof(decimal), "Fee to use for the withdrawal", 0.001m)
             }
         };
 
@@ -817,7 +817,7 @@ namespace OKX.Net.Clients.UnifiedApi
             if (request.AddressTag != null)
                 target += ":" + request.AddressTag;
 
-            var fee = ExchangeParameters.GetValue<decimal>(request.ExchangeParameters, Exchange, "withdrawFee");
+            var fee = request.GetParamValue<decimal>(Exchange, "withdrawFee", "fee");
 
             // Get data
             var withdrawal = await Account.WithdrawAsync(

--- a/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiShared.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiShared.cs
@@ -20,7 +20,7 @@ namespace OKX.Net.Clients.UnifiedApi
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
-        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(OKXExchange.Metadata, this);
 
         #region Kline client
 
@@ -116,20 +116,20 @@ namespace OKX.Net.Clients.UnifiedApi
                 PriceStep = s.TickSize
             }).ToArray());
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, response.Data!);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, EnvironmentName, null, response.Data!);
             return response;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicSpotId))
+            if (!ExchangeSymbolCache.HasCached(_topicSpotId, EnvironmentName, null))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicSpotId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicSpotId, EnvironmentName, null, baseAsset));
         }
 
         async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(SharedSymbol symbol)
@@ -137,26 +137,26 @@ namespace OKX.Net.Clients.UnifiedApi
             if (symbol.TradingMode != TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Only Spot symbols allowed");
 
-            if (!ExchangeSymbolCache.HasCached(_topicSpotId))
+            if (!ExchangeSymbolCache.HasCached(_topicSpotId, EnvironmentName, null))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, EnvironmentName, null, symbol));
         }
 
         async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(string symbolName)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicSpotId))
+            if (!ExchangeSymbolCache.HasCached(_topicSpotId, EnvironmentName, null))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, EnvironmentName, null, symbolName));
         }
         #endregion
 
@@ -174,7 +174,14 @@ namespace OKX.Net.Clients.UnifiedApi
             if (!result.Success)
                 return HttpResult.Fail<SharedSpotTicker>(result);
 
-            return HttpResult.Ok(result, new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicSpotId, symbol), symbol, result.Data.LastPrice ?? 0, result.Data.HighPrice ?? 0, result.Data.LowPrice ?? 0, result.Data.Volume, result.Data.OpenPrice == null ? null : Math.Round((result.Data.LastPrice ?? 0) / result.Data.OpenPrice.Value * 100 - 100, 2))
+            return HttpResult.Ok(result, new SharedSpotTicker(
+                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, symbol),
+                symbol,
+                result.Data.LastPrice ?? 0, 
+                result.Data.HighPrice ?? 0, 
+                result.Data.LowPrice ?? 0,
+                result.Data.Volume,
+                result.Data.OpenPrice == null ? null : Math.Round((result.Data.LastPrice ?? 0) / result.Data.OpenPrice.Value * 100 - 100, 2))
             {
                 QuoteVolume = result.Data.QuoteVolume
             });
@@ -191,10 +198,18 @@ namespace OKX.Net.Clients.UnifiedApi
             if (!result.Success)
                 return HttpResult.Fail<SharedSpotTicker[]>(result);
 
-            return HttpResult.Ok(result, result.Data.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), x.Symbol, x.LastPrice ?? 0, x.HighPrice ?? 0, x.LowPrice ?? 0, x.Volume, x.OpenPrice == null ? null : Math.Round((x.LastPrice ?? 0) / x.OpenPrice.Value * 100 - 100, 2))
-            {
-                QuoteVolume = x.QuoteVolume
-            }).ToArray());
+            return HttpResult.Ok(result, result.Data.Select(x => 
+                new SharedSpotTicker(
+                    ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, x.Symbol),
+                    x.Symbol,
+                    x.LastPrice ?? 0,
+                    x.HighPrice ?? 0,
+                    x.LowPrice ?? 0,
+                    x.Volume,
+                    x.OpenPrice == null ? null : Math.Round((x.LastPrice ?? 0) / x.OpenPrice.Value * 100 - 100, 2))
+                {
+                    QuoteVolume = x.QuoteVolume
+                }).ToArray());
         }
 
         #endregion
@@ -213,7 +228,7 @@ namespace OKX.Net.Clients.UnifiedApi
                 return HttpResult.Fail<SharedBookTicker>(resultTicker);
 
             return HttpResult.Ok(resultTicker, new SharedBookTicker(
-                ExchangeSymbolCache.ParseSymbol(request.Symbol.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, resultTicker.Data.Symbol),
+                ExchangeSymbolCache.ParseSymbol(request.Symbol.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, EnvironmentName, null, resultTicker.Data.Symbol),
                 resultTicker.Data.Symbol,
                 resultTicker.Data.BestAskPrice ?? 0,
                 resultTicker.Data.BestAskQuantity ?? 0,
@@ -334,7 +349,7 @@ namespace OKX.Net.Clients.UnifiedApi
                 return HttpResult.Fail<SharedSpotOrder>(order);
 
             return HttpResult.Ok(order, new SharedSpotOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicSpotId, order.Data.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, order.Data.Symbol),
                 order.Data.Symbol,
                 order.Data.OrderId.ToString()!,
                 ParseOrderType(order.Data.OrderType),
@@ -367,7 +382,7 @@ namespace OKX.Net.Clients.UnifiedApi
                 return HttpResult.Fail<SharedSpotOrder[]>(order);
 
             return HttpResult.Ok(order, order.Data.Select(x => new SharedSpotOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
+                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString()!,
                 ParseOrderType(x.OrderType),
@@ -425,7 +440,7 @@ namespace OKX.Net.Clients.UnifiedApi
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                 .Select(x => 
                     new SharedSpotOrder(
-                        ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
+                        ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, x.Symbol), 
                         x.Symbol,
                         x.OrderId.ToString()!,
                         ParseOrderType(x.OrderType),
@@ -462,7 +477,7 @@ namespace OKX.Net.Clients.UnifiedApi
                 return HttpResult.Fail<SharedUserTrade[]>(order);
 
             return HttpResult.Ok(order, order.Data.Select(x => new SharedUserTrade(
-                ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
+                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString()!,
                 x.TradeId.ToString()!,
@@ -518,7 +533,7 @@ namespace OKX.Net.Clients.UnifiedApi
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
                 .Select(x =>
                     new SharedUserTrade(
-                        ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
+                        ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, x.Symbol), 
                         x.Symbol,
                         x.OrderId.ToString()!,
                         x.TradeId.ToString()!,
@@ -876,24 +891,71 @@ namespace OKX.Net.Clients.UnifiedApi
             if (validationError != null)
                 return HttpResult.Fail<SharedFuturesSymbol[]>(Exchange, validationError);
 
-            var type = (!request.TradingMode.HasValue || request.TradingMode == TradingMode.PerpetualLinear || request.TradingMode == TradingMode.PerpetualInverse) ? InstrumentType.Swap : InstrumentType.Futures;
-            var result = await ExchangeData.GetSymbolsAsync(type, ct: ct).ConfigureAwait(false);
-            if (!result.Success)
-                return HttpResult.Fail<SharedFuturesSymbol[]>(result);
+            // For Europe environment there are 2 different types of perp contracts
+            //   1. Swaps, do not appear to be tradable, but still returned by the server
+            //   2. XPerps, which are returned under InstrumentType.Futures with a delivery time of 5 years
+            // Which one we return is determined by the configuration
 
-            IEnumerable<OKXInstrument> data = result.Data;
+            var europeXPerps = EnvironmentName == OKXEnvironment.Europe.Name && ClientOptions.SharedApiEuropeUseXPerps;
+
+            IEnumerable<OKXInstrument> data;
+            HttpResult<OKXInstrument[]> result;
+            if (request.TradingMode == null)
+            {
+                // No trading mode filter, request both Swap (perps) and Futures (delivery)
+                var request1 = ExchangeData.GetSymbolsAsync(InstrumentType.Swap, ct: ct);
+                var request2 = ExchangeData.GetSymbolsAsync(InstrumentType.Futures, ct: ct);
+                await Task.WhenAll(request1, request2).ConfigureAwait(false);
+                if (!request1.Result.Success)
+                    return HttpResult.Fail<SharedFuturesSymbol[]>(request1.Result);
+                if (!request2.Result.Success)
+                    return HttpResult.Fail<SharedFuturesSymbol[]>(request2.Result);
+
+                result = request1.Result;
+                data = request1.Result.Data.Concat(request2.Result.Data);
+            }
+            else
+            {
+                InstrumentType requestType;
+                if (europeXPerps)
+                    requestType = InstrumentType.Futures; // Europe XPerps are returned as futures with 5y delivery
+                else
+                    requestType = (!request.TradingMode.HasValue || request.TradingMode == TradingMode.PerpetualLinear || request.TradingMode == TradingMode.PerpetualInverse) ? InstrumentType.Swap : InstrumentType.Futures;
+
+                result = await ExchangeData.GetSymbolsAsync(requestType, ct: ct).ConfigureAwait(false);
+                if (!result.Success)
+                    return HttpResult.Fail<SharedFuturesSymbol[]>(result);
+
+                data = result.Data;
+            }
+            
             if (request.TradingMode.HasValue)
-                data = data.Where(x =>
-                    request.TradingMode == TradingMode.PerpetualLinear ? (x.ContractType == ContractType.Linear && x.ExpiryTime == null) :
-                    request.TradingMode == TradingMode.PerpetualInverse ? (x.ContractType == ContractType.Inverse && x.ExpiryTime == null) :
-                    request.TradingMode == TradingMode.DeliveryLinear ? (x.ContractType == ContractType.Linear && x.ExpiryTime != null) :
-                    (x.ContractType == ContractType.Inverse && x.ExpiryTime != null));
+            {
+                if (europeXPerps)
+                {
+                    data = data.Where(x =>
+                        request.TradingMode == TradingMode.PerpetualLinear ? (x.ContractType == ContractType.Linear && x.RuleType == SymbolRuleType.Perp) :
+                        request.TradingMode == TradingMode.PerpetualInverse ? (x.ContractType == ContractType.Inverse && x.RuleType == SymbolRuleType.Perp) :
+                        request.TradingMode == TradingMode.DeliveryLinear ? (x.ContractType == ContractType.Linear && x.RuleType != SymbolRuleType.Perp) :
+                        (x.ContractType == ContractType.Inverse && x.RuleType != SymbolRuleType.Perp));
+                }
+                else
+                {
+                    data = data.Where(x =>
+                        request.TradingMode == TradingMode.PerpetualLinear ? (x.ContractType == ContractType.Linear && x.ExpiryTime == null) :
+                        request.TradingMode == TradingMode.PerpetualInverse ? (x.ContractType == ContractType.Inverse && x.ExpiryTime == null) :
+                        request.TradingMode == TradingMode.DeliveryLinear ? (x.ContractType == ContractType.Linear && x.ExpiryTime != null) :
+                        (x.ContractType == ContractType.Inverse && x.ExpiryTime != null));
+                }
+            }
             
             var response = HttpResult.Ok(result,
                 data.Select(x => new SharedFuturesSymbol(
-                x.ContractType == ContractType.Linear ? TradingMode.PerpetualLinear : TradingMode.PerpetualInverse,
-                x.Symbol.Split('-')[0],
-                x.Symbol.Split('-')[1],
+                    x.InstrumentType == InstrumentType.Swap 
+                    ? (x.ContractType == ContractType.Linear ? TradingMode.PerpetualLinear : TradingMode.PerpetualInverse)
+                    : (x.ContractType == ContractType.Linear ? (x.RuleType == SymbolRuleType.Perp ? TradingMode.PerpetualLinear : TradingMode.DeliveryLinear) : (x.RuleType == SymbolRuleType.Perp ? TradingMode.PerpetualInverse : TradingMode.DeliveryInverse)),
+                x.Underlying.Split('-')[0],
+                x.Underlying.Split('-')[1],
                 x.Symbol,
                 x.State == InstrumentState.Live)
                 {
@@ -907,21 +969,21 @@ namespace OKX.Net.Clients.UnifiedApi
                     MaxShortLeverage = x.MaximumLeverage
                 }).ToArray());
 
-
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, response.Data!);
+            foreach(var distinctMode in response.Data!.GroupBy(x => x.TradingMode))
+                ExchangeSymbolCache.UpdateSymbolInfo(_topicFuturesId, EnvironmentName, distinctMode.Key.ToString(), distinctMode.ToArray());
             return response;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicFuturesId))
+            if (!ExchangeSymbolCache.HasCached(_topicFuturesId, EnvironmentName, null))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicFuturesId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicFuturesId, EnvironmentName, null, baseAsset));
         }
 
         async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(SharedSymbol symbol)
@@ -929,26 +991,26 @@ namespace OKX.Net.Clients.UnifiedApi
             if (symbol.TradingMode == TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Spot symbols not allowed");
 
-            if (!ExchangeSymbolCache.HasCached(_topicFuturesId))
+            if (!ExchangeSymbolCache.HasCached(_topicFuturesId, EnvironmentName, null))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, EnvironmentName, null, symbol));
         }
 
         async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(string symbolName)
         {
-            if (!ExchangeSymbolCache.HasCached(_topicFuturesId))
+            if (!ExchangeSymbolCache.HasCached(_topicFuturesId, EnvironmentName, null))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
                 if (!symbols.Success)
                     return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, EnvironmentName, null, symbolName));
         }
         #endregion
 
@@ -1012,7 +1074,7 @@ namespace OKX.Net.Clients.UnifiedApi
                 return HttpResult.Fail<SharedFuturesOrder>(order);
 
             return HttpResult.Ok(order, new SharedFuturesOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, order.Data.Symbol), 
+                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, order.Data.Symbol), 
                 order.Data.Symbol,
                 order.Data.OrderId.ToString()!,
                 ParseOrderType(order.Data.OrderType),
@@ -1056,7 +1118,7 @@ namespace OKX.Net.Clients.UnifiedApi
                 return HttpResult.Fail<SharedFuturesOrder[]>(orders);
 
             return HttpResult.Ok(orders, orders.Data.Select(x => new SharedFuturesOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
+                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString()!,
                 ParseOrderType(x.OrderType),
@@ -1137,7 +1199,7 @@ namespace OKX.Net.Clients.UnifiedApi
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                 .Select(x => 
                     new SharedFuturesOrder(
-                        ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
+                        ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol), 
                         x.Symbol,
                         x.OrderId.ToString()!,
                         ParseOrderType(x.OrderType),
@@ -1196,7 +1258,7 @@ namespace OKX.Net.Clients.UnifiedApi
                 return HttpResult.Fail<SharedUserTrade[]>(orders);
 
             return HttpResult.Ok(orders, orders.Data.Select(x => new SharedUserTrade(
-                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
+                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString()!,
                 x.TradeId.ToString()!,
@@ -1269,7 +1331,7 @@ namespace OKX.Net.Clients.UnifiedApi
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
                 .Select(x => 
                     new SharedUserTrade(
-                        ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
+                        ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol), 
                         x.Symbol,
                         x.OrderId.ToString()!,
                         x.TradeId.ToString()!,
@@ -1314,17 +1376,22 @@ namespace OKX.Net.Clients.UnifiedApi
             if (!result.Success)
                 return HttpResult.Fail<SharedPosition[]>(result);
 
-            return HttpResult.Ok(result, result.Data.Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), x.Symbol, Math.Abs(x.PositionsQuantity ?? 0), x.UpdateTime)
-            {
-                UnrealizedPnl = x.UnrealizedPnl,
-                LiquidationPrice = x.LiquidationPrice,
-                Leverage = x.Leverage,
-                AverageOpenPrice = x.AveragePrice,
-                PositionMode = x.PositionSide == PositionSide.Net ? SharedPositionMode.OneWay : SharedPositionMode.HedgeMode,
-                PositionSide = x.PositionSide == PositionSide.Net ? (x.PositionsQuantity >= 0 ? SharedPositionSide.Long : SharedPositionSide.Short) : x.PositionSide == PositionSide.Short ? SharedPositionSide.Short : SharedPositionSide.Long,
-                StopLossPrice = x.CloseOrderAlgo.FirstOrDefault(x => x.StopLossTriggerPrice > 0)?.StopLossTriggerPrice,
-                TakeProfitPrice = x.CloseOrderAlgo.FirstOrDefault(x => x.TakeProfitTriggerPrice > 0)?.TakeProfitTriggerPrice
-            }).ToArray());
+            return HttpResult.Ok(result, result.Data.Select(x => 
+                new SharedPosition(
+                    ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol),
+                    x.Symbol, 
+                    Math.Abs(x.PositionsQuantity ?? 0),
+                    x.UpdateTime)
+                {
+                    UnrealizedPnl = x.UnrealizedPnl,
+                    LiquidationPrice = x.LiquidationPrice,
+                    Leverage = x.Leverage,
+                    AverageOpenPrice = x.AveragePrice,
+                    PositionMode = x.PositionSide == PositionSide.Net ? SharedPositionMode.OneWay : SharedPositionMode.HedgeMode,
+                    PositionSide = x.PositionSide == PositionSide.Net ? (x.PositionsQuantity >= 0 ? SharedPositionSide.Long : SharedPositionSide.Short) : x.PositionSide == PositionSide.Short ? SharedPositionSide.Short : SharedPositionSide.Long,
+                    StopLossPrice = x.CloseOrderAlgo.FirstOrDefault(x => x.StopLossTriggerPrice > 0)?.StopLossTriggerPrice,
+                    TakeProfitPrice = x.CloseOrderAlgo.FirstOrDefault(x => x.TakeProfitTriggerPrice > 0)?.TakeProfitTriggerPrice
+                }).ToArray());
         }
 
         ClosePositionOptions IFuturesOrderRestClient.ClosePositionOptions { get; } = new ClosePositionOptions(_exchangeName, true)
@@ -1591,7 +1658,7 @@ namespace OKX.Net.Clients.UnifiedApi
             var index = resultIndexPrice.Result.Data.Single();
             var mark = resultMarkPrice.Result.Data.Single();
             return HttpResult.Ok(resultTicker.Result, new SharedFuturesTicker(
-                    ExchangeSymbolCache.ParseSymbol(_topicFuturesId, resultTicker.Result.Data.Symbol),
+                    ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, resultTicker.Result.Data.Symbol),
                     resultTicker.Result.Data.Symbol,
                     resultTicker.Result.Data.LastPrice,
                     resultTicker.Result.Data.HighPrice,
@@ -1625,7 +1692,14 @@ namespace OKX.Net.Clients.UnifiedApi
             return HttpResult.Ok(resultTickers.Result, resultTickers.Result.Data.Select(x =>
             {
                 var markPrice = resultMarkPrice.Result.Data.Single(p => p.Symbol == x.Symbol);
-                return new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.Volume, x.OpenPrice == null ? null : Math.Round((x.LastPrice ?? 0) / x.OpenPrice.Value * 100 - 100, 2))
+                return new SharedFuturesTicker(
+                    ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol), 
+                    x.Symbol,
+                    x.LastPrice,
+                    x.HighPrice,
+                    x.LowPrice,
+                    x.Volume,
+                    x.OpenPrice == null ? null : Math.Round((x.LastPrice ?? 0) / x.OpenPrice.Value * 100 - 100, 2))
                 {
                     MarkPrice = markPrice.MarkPrice
                 };
@@ -1701,7 +1775,7 @@ namespace OKX.Net.Clients.UnifiedApi
             return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                     .Select(x => 
                         new SharedPositionHistory(
-                            ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
+                            ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol), 
                             x.Symbol,
                             x.Direction == PositionSide.Short ? SharedPositionSide.Short : SharedPositionSide.Long,
                             x.OpenAveragePrice ?? 0,
@@ -1789,7 +1863,7 @@ namespace OKX.Net.Clients.UnifiedApi
             }
 
             return HttpResult.Ok(order, new SharedSpotTriggerOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicSpotId, order.Data.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, order.Data.Symbol),
                 order.Data.Symbol!,
                 order.Data.AlgoId!,
                 order.Data.OrderPrice > 0 ? SharedOrderType.Limit : SharedOrderType.Market,
@@ -1910,7 +1984,7 @@ namespace OKX.Net.Clients.UnifiedApi
             }
 
             return HttpResult.Ok(order, new SharedFuturesTriggerOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, order.Data.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, order.Data.Symbol),
                 order.Data.Symbol!,
                 order.Data.AlgoId!,
                 order.Data.OrderPrice > 0 ? SharedOrderType.Limit : SharedOrderType.Market,
@@ -2032,7 +2106,7 @@ namespace OKX.Net.Clients.UnifiedApi
                 return HttpResult.Fail<SharedFuturesOrder>(order);
 
             return HttpResult.Ok(order, new SharedFuturesOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, order.Data.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, order.Data.Symbol),
                 order.Data.Symbol,
                 order.Data.OrderId.ToString()!,
                 ParseOrderType(order.Data.OrderType),
@@ -2086,7 +2160,7 @@ namespace OKX.Net.Clients.UnifiedApi
                 return HttpResult.Fail<SharedSpotOrder>(order);
 
             return HttpResult.Ok(order, new SharedSpotOrder(
-                ExchangeSymbolCache.ParseSymbol(_topicSpotId, order.Data.Symbol),
+                ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, order.Data.Symbol),
                 order.Data.Symbol,
                 order.Data.OrderId.ToString()!,
                 ParseOrderType(order.Data.OrderType),

--- a/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiShared.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiShared.cs
@@ -12,17 +12,18 @@ namespace OKX.Net.Clients.UnifiedApi
     {
         private const string _topicSpotId = "OKXSpot";
         private const string _topicFuturesId = "OKXFutures";
+        private const string _exchangeName = "OKX";
 
-        public string Exchange => OKXExchange.ExchangeName;
         public TradingMode[] SupportedTradingModes { get; } = new[] { TradingMode.Spot, TradingMode.PerpetualLinear, TradingMode.PerpetualInverse, TradingMode.DeliveryLinear, TradingMode.DeliveryInverse };
         private TradingMode[] FuturesApiTypes { get; } = new[] { TradingMode.PerpetualLinear, TradingMode.DeliveryLinear, TradingMode.PerpetualInverse, TradingMode.DeliveryInverse };
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
 
         #region Kline client
 
-        GetKlinesOptions IKlineRestClient.GetKlinesOptions { get; } = new GetKlinesOptions(false, true, true, 100, false,
+        GetKlinesOptions IKlineRestClient.GetKlinesOptions { get; } = new GetKlinesOptions(_exchangeName, false, true, true, 100, false,
             SharedKlineInterval.OneMinute,
             SharedKlineInterval.FiveMinutes,
             SharedKlineInterval.FifteenMinutes,
@@ -35,22 +36,20 @@ namespace OKX.Net.Clients.UnifiedApi
             SharedKlineInterval.OneDay,
             SharedKlineInterval.OneWeek,
             SharedKlineInterval.OneMonth);
-        async Task<ExchangeWebResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedKline[]>> IKlineRestClient.GetKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
             var interval = (KlineInterval)request.Interval;
-            if (!Enum.IsDefined(typeof(KlineInterval), interval))
-                return new ExchangeWebResult<SharedKline[]>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
 
-            var validationError = ((IKlineRestClient)this).GetKlinesOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetKlinesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedKline[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedKline[]>(Exchange, validationError);
 
             int limit = request.Limit ?? 100;
             var direction = DataDirection.Descending;
             var pageParams = Pagination.GetPaginationParameters(direction, limit, request.StartTime, request.EndTime ?? DateTime.UtcNow, pageRequest, false);
 
             // Get data
-            WebCallResult<OKXKline[]> result;
+            HttpResult<OKXKline[]> result;
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             if (pageParams.EndTime > DateTime.UtcNow.AddSeconds(-(2 * (int)request.Interval)))
             {
@@ -76,8 +75,8 @@ namespace OKX.Net.Clients.UnifiedApi
                     ).ConfigureAwait(false);
             }
 
-            if (!result)
-                return result.AsExchangeResult<SharedKline[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedKline[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                      () => Pagination.NextPageFromTime(pageParams, result.Data.Min(x => x.Time)),
@@ -87,10 +86,7 @@ namespace OKX.Net.Clients.UnifiedApi
                      request.EndTime ?? DateTime.UtcNow,
                      pageParams);
 
-            return result.AsExchangeResult(
-                    Exchange,
-                    request.Symbol.TradingMode,
-                    ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
                     .Select(x =>
                         new SharedKline(request.Symbol, symbol, x.Time, x.ClosePrice, x.HighPrice, x.LowPrice, x.OpenPrice, x.Volume))
                     .ToArray(), nextPageRequest);
@@ -100,18 +96,18 @@ namespace OKX.Net.Clients.UnifiedApi
 
         #region Spot Symbol client
 
-        EndpointOptions<GetSymbolsRequest> ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest>(false);
-        async Task<ExchangeWebResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
+        GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
+        async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotSymbolRestClient)this).GetSpotSymbolsOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotSymbolsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotSymbol[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotSymbol[]>(Exchange, validationError);
 
             var result = await ExchangeData.GetSymbolsAsync(InstrumentType.Spot, ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotSymbol[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedSpotSymbol[]>(result);
 
-            var response = result.AsExchangeResult<SharedSpotSymbol[]>(Exchange, TradingMode.Spot, result.Data.Select(s => new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Symbol, s.State == InstrumentState.Live)
+            var response = HttpResult.Ok(result, result.Data.Select(s => new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Symbol, s.State == InstrumentState.Live)
             {
                 MaxTradeQuantity = Math.Min(s.MaxLimitQuantity ?? decimal.MaxValue, s.MaxMarketQuantity ?? decimal.MaxValue),
                 MinTradeQuantity = s.MinimumOrderSize,
@@ -119,23 +115,23 @@ namespace OKX.Net.Clients.UnifiedApi
                 PriceStep = s.TickSize
             }).ToArray());
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, response.Data);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, response.Data!);
             return response;
         }
 
-        async Task<ExchangeResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
+        async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
         {
             if (!ExchangeSymbolCache.HasCached(_topicSpotId))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<SharedSymbol[]>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<SharedSymbol[]>(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicSpotId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicSpotId, baseAsset));
         }
 
-        async Task<ExchangeResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(SharedSymbol symbol)
+        async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(SharedSymbol symbol)
         {
             if (symbol.TradingMode != TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Only Spot symbols allowed");
@@ -143,58 +139,58 @@ namespace OKX.Net.Clients.UnifiedApi
             if (!ExchangeSymbolCache.HasCached(_topicSpotId))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, symbol));
         }
 
-        async Task<ExchangeResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(string symbolName)
+        async Task<ExchangeCallResult<bool>> ISpotSymbolRestClient.SupportsSpotSymbolAsync(string symbolName)
         {
             if (!ExchangeSymbolCache.HasCached(_topicSpotId))
             {
                 var symbols = await ((ISpotSymbolRestClient)this).GetSpotSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicSpotId, symbolName));
         }
         #endregion
 
         #region Spot Ticker client
 
-        GetTickerOptions ISpotTickerRestClient.GetSpotTickerOptions { get; } = new GetTickerOptions();
-        async Task<ExchangeWebResult<SharedSpotTicker>> ISpotTickerRestClient.GetSpotTickerAsync(GetTickerRequest request, CancellationToken ct)
+        GetSpotTickerOptions ISpotTickerRestClient.GetSpotTickerOptions { get; } = new GetSpotTickerOptions(_exchangeName);
+        async Task<HttpResult<SharedSpotTicker>> ISpotTickerRestClient.GetSpotTickerAsync(GetTickerRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTickerRestClient)this).GetSpotTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotTicker>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotTicker>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.GetTickerAsync(symbol, ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotTicker>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedSpotTicker>(result);
 
-            return result.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicSpotId, symbol), symbol, result.Data.LastPrice ?? 0, result.Data.HighPrice ?? 0, result.Data.LowPrice ?? 0, result.Data.Volume, result.Data.OpenPrice == null ? null : Math.Round((result.Data.LastPrice ?? 0) / result.Data.OpenPrice.Value * 100 - 100, 2))
+            return HttpResult.Ok(result, new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicSpotId, symbol), symbol, result.Data.LastPrice ?? 0, result.Data.HighPrice ?? 0, result.Data.LowPrice ?? 0, result.Data.Volume, result.Data.OpenPrice == null ? null : Math.Round((result.Data.LastPrice ?? 0) / result.Data.OpenPrice.Value * 100 - 100, 2))
             {
                 QuoteVolume = result.Data.QuoteVolume
             });
         }
 
-        GetTickersOptions ISpotTickerRestClient.GetSpotTickersOptions { get; } = new GetTickersOptions();
-        async Task<ExchangeWebResult<SharedSpotTicker[]>> ISpotTickerRestClient.GetSpotTickersAsync(GetTickersRequest request, CancellationToken ct)
+        GetSpotTickersOptions ISpotTickerRestClient.GetSpotTickersOptions { get; } = new GetSpotTickersOptions(_exchangeName);
+        async Task<HttpResult<SharedSpotTicker[]>> ISpotTickerRestClient.GetSpotTickersAsync(GetTickersRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTickerRestClient)this).GetSpotTickersOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotTickersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotTicker[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotTicker[]>(Exchange, validationError);
 
             var result = await ExchangeData.GetTickersAsync(InstrumentType.Spot, ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotTicker[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedSpotTicker[]>(result);
 
-            return result.AsExchangeResult<SharedSpotTicker[]>(Exchange, TradingMode.Spot, result.Data.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), x.Symbol, x.LastPrice ?? 0, x.HighPrice ?? 0, x.LowPrice ?? 0, x.Volume, x.OpenPrice == null ? null : Math.Round((x.LastPrice ?? 0) / x.OpenPrice.Value * 100 - 100, 2))
+            return HttpResult.Ok(result, result.Data.Select(x => new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), x.Symbol, x.LastPrice ?? 0, x.HighPrice ?? 0, x.LowPrice ?? 0, x.Volume, x.OpenPrice == null ? null : Math.Round((x.LastPrice ?? 0) / x.OpenPrice.Value * 100 - 100, 2))
             {
                 QuoteVolume = x.QuoteVolume
             }).ToArray());
@@ -204,18 +200,18 @@ namespace OKX.Net.Clients.UnifiedApi
 
         #region Book Ticker client
 
-        EndpointOptions<GetBookTickerRequest> IBookTickerRestClient.GetBookTickerOptions { get; } = new EndpointOptions<GetBookTickerRequest>(false);
-        async Task<ExchangeWebResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
+        GetBookTickerOptions IBookTickerRestClient.GetBookTickerOptions { get; } = new GetBookTickerOptions(_exchangeName, false);
+        async Task<HttpResult<SharedBookTicker>> IBookTickerRestClient.GetBookTickerAsync(GetBookTickerRequest request, CancellationToken ct)
         {
-            var validationError = ((IBookTickerRestClient)this).GetBookTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetBookTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedBookTicker>(Exchange, validationError);
+                return HttpResult.Fail<SharedBookTicker>(Exchange, validationError);
 
             var resultTicker = await ExchangeData.GetTickerAsync(request.Symbol!.GetSymbol(FormatSymbol), ct: ct).ConfigureAwait(false);
-            if (!resultTicker)
-                return resultTicker.AsExchangeResult<SharedBookTicker>(Exchange, null, default);
+            if (!resultTicker.Success)
+                return HttpResult.Fail<SharedBookTicker>(resultTicker);
 
-            return resultTicker.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedBookTicker(
+            return HttpResult.Ok(resultTicker, new SharedBookTicker(
                 ExchangeSymbolCache.ParseSymbol(request.Symbol.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, resultTicker.Data.Symbol),
                 resultTicker.Data.Symbol,
                 resultTicker.Data.BestAskPrice ?? 0,
@@ -228,22 +224,22 @@ namespace OKX.Net.Clients.UnifiedApi
 
         #region Recent Trade client
 
-        GetRecentTradesOptions IRecentTradeRestClient.GetRecentTradesOptions { get; } = new GetRecentTradesOptions(100, false);
-        async Task<ExchangeWebResult<SharedTrade[]>> IRecentTradeRestClient.GetRecentTradesAsync(GetRecentTradesRequest request, CancellationToken ct)
+        GetRecentTradesOptions IRecentTradeRestClient.GetRecentTradesOptions { get; } = new GetRecentTradesOptions(_exchangeName, 100, false);
+        async Task<HttpResult<SharedTrade[]>> IRecentTradeRestClient.GetRecentTradesAsync(GetRecentTradesRequest request, CancellationToken ct)
         {
-            var validationError = ((IRecentTradeRestClient)this).GetRecentTradesOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetRecentTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedTrade[]>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var result = await ExchangeData.GetTradeHistoryAsync(
                 symbol,
                 limit: request.Limit ?? 100,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedTrade[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedTrade[]>(result);
 
-            return result.AsExchangeResult<SharedTrade[]>(Exchange, request.Symbol.TradingMode, result.Data.Select(x => 
+            return HttpResult.Ok(result, result.Data.Select(x => 
             new SharedTrade(request.Symbol, symbol, x.Quantity, x.Price, x.Time)
             {
                 Side = x.Side == OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell
@@ -253,30 +249,30 @@ namespace OKX.Net.Clients.UnifiedApi
         #endregion
 
         #region Balance client
-        GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(
+        GetBalancesOptions IBalanceRestClient.GetBalancesOptions { get; } = new GetBalancesOptions(_exchangeName, 
             AccountTypeFilter.Funding, AccountTypeFilter.Spot, AccountTypeFilter.Futures, AccountTypeFilter.Margin, AccountTypeFilter.Option);
 
-        async Task<ExchangeWebResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedBalance[]>> IBalanceRestClient.GetBalancesAsync(GetBalancesRequest request, CancellationToken ct)
         {
-            var validationError = ((IBalanceRestClient)this).GetBalancesOptions.ValidateRequest(Exchange, request, SupportedTradingModes);
+            var validationError = SharedClient.GetBalancesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedBalance[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedBalance[]>(Exchange, validationError);
 
             if (request.AccountType != SharedAccountType.Funding)
             {
                 var result = await Account.GetAccountBalanceAsync(ct: ct).ConfigureAwait(false);
-                if (!result)
-                    return result.AsExchangeResult<SharedBalance[]>(Exchange, null, default);
+                if (!result.Success)
+                    return HttpResult.Fail<SharedBalance[]>(result);
 
-                return result.AsExchangeResult<SharedBalance[]>(Exchange, SupportedTradingModes, result.Data.Details.Select(x => new SharedBalance(x.Asset, x.AvailableBalance ?? 0, x.Equity ?? 0)).ToArray());
+                return HttpResult.Ok(result, result.Data.Details.Select(x => new SharedBalance(x.Asset, x.AvailableBalance ?? 0, x.Equity ?? 0)).ToArray());
             }
             else
             {
                 var result = await Account.GetFundingBalanceAsync(ct: ct).ConfigureAwait(false);
-                if (!result)
-                    return result.AsExchangeResult<SharedBalance[]>(Exchange, null, default);
+                if (!result.Success)
+                    return HttpResult.Fail<SharedBalance[]>(result);
 
-                return result.AsExchangeResult(Exchange, SupportedTradingModes, result.Data.Select(x => new SharedBalance(x.Asset, x.Available, x.Balance)).ToArray());
+                return HttpResult.Ok(result, result.Data.Select(x => new SharedBalance(x.Asset, x.Available, x.Balance)).ToArray());
             }
         }
 
@@ -298,20 +294,13 @@ namespace OKX.Net.Clients.UnifiedApi
 
         string ISpotOrderRestClient.GenerateClientOrderId() => ExchangeHelpers.RandomString(32);
 
-        PlaceSpotOrderOptions ISpotOrderRestClient.PlaceSpotOrderOptions { get; } = new PlaceSpotOrderOptions();
+        PlaceSpotOrderOptions ISpotOrderRestClient.PlaceSpotOrderOptions { get; } = new PlaceSpotOrderOptions(_exchangeName);
 
-        async Task<ExchangeWebResult<SharedId>> ISpotOrderRestClient.PlaceSpotOrderAsync(PlaceSpotOrderRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> ISpotOrderRestClient.PlaceSpotOrderAsync(PlaceSpotOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).PlaceSpotOrderOptions.ValidateRequest(
-                Exchange,
-                request,
-                request.TradingMode,
-                new[] { TradingMode.Spot },
-                ((ISpotOrderRestClient)this).SpotSupportedOrderTypes,
-                ((ISpotOrderRestClient)this).SpotSupportedTimeInForce,
-                ((ISpotOrderRestClient)this).SpotSupportedOrderQuantity);
+            var validationError = SharedClient.PlaceSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await Trading.PlaceOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -323,27 +312,27 @@ namespace OKX.Net.Clients.UnifiedApi
                 clientOrderId: request.ClientOrderId,
                 ct: ct).ConfigureAwait(false);
 
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(result.Data.OrderId.ToString()!));
+            return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()!));
         }
 
-        EndpointOptions<GetOrderRequest> ISpotOrderRestClient.GetSpotOrderOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedSpotOrder>> ISpotOrderRestClient.GetSpotOrderAsync(GetOrderRequest request, CancellationToken ct)
+        GetSpotOrderOptions ISpotOrderRestClient.GetSpotOrderOptions { get; } = new GetSpotOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedSpotOrder>> ISpotOrderRestClient.GetSpotOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, new[] { TradingMode.Spot });
+            var validationError = SharedClient.GetSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotOrder>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedSpotOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderRequest), "Invalid order id"));
+                return HttpResult.Fail<SharedSpotOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderRequest), "Invalid order id"));
 
             var order = await Trading.GetOrderDetailsAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedSpotOrder>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedSpotOrder>(order);
 
-            return order.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotOrder(
+            return HttpResult.Ok(order, new SharedSpotOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicSpotId, order.Data.Symbol),
                 order.Data.Symbol,
                 order.Data.OrderId.ToString()!,
@@ -364,19 +353,19 @@ namespace OKX.Net.Clients.UnifiedApi
             });
         }
 
-        EndpointOptions<GetOpenOrdersRequest> ISpotOrderRestClient.GetOpenSpotOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest>(true);
-        async Task<ExchangeWebResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetOpenSpotOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
+        GetOpenSpotOrdersOptions ISpotOrderRestClient.GetOpenSpotOrdersOptions { get; } = new GetOpenSpotOrdersOptions(_exchangeName, true);
+        async Task<HttpResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetOpenSpotOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetOpenSpotOrdersOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, new[] { TradingMode.Spot });
+            var validationError = SharedClient.GetOpenSpotOrdersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotOrder[]>(Exchange, validationError);
 
             var symbol = request.Symbol?.GetSymbol(FormatSymbol);
             var order = await Trading.GetOrdersAsync(symbol: symbol, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedSpotOrder[]>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedSpotOrder[]>(order);
 
-            return order.AsExchangeResult<SharedSpotOrder[]>(Exchange, TradingMode.Spot, order.Data.Select(x => new SharedSpotOrder(
+            return HttpResult.Ok(order, order.Data.Select(x => new SharedSpotOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString()!,
@@ -397,15 +386,15 @@ namespace OKX.Net.Clients.UnifiedApi
             }).ToArray());
         }
 
-        GetClosedOrdersOptions ISpotOrderRestClient.GetClosedSpotOrdersOptions { get; } = new GetClosedOrdersOptions(false, true, true, 100)
+        GetSpotClosedOrdersOptions ISpotOrderRestClient.GetClosedSpotOrdersOptions { get; } = new GetSpotClosedOrdersOptions(_exchangeName, false, true, true, 100)
         {
             MaxAge = TimeSpan.FromDays(90)
         };
-        async Task<ExchangeWebResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetClosedSpotOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedSpotOrder[]>> ISpotOrderRestClient.GetClosedSpotOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetClosedSpotOrdersOptions.ValidateRequest(Exchange, request, request.TradingMode, new[] { TradingMode.Spot });
+            var validationError = SharedClient.GetClosedSpotOrdersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotOrder[]>(Exchange, validationError);
 
             // Determine page token
             int limit = request.Limit ?? 100;
@@ -420,8 +409,8 @@ namespace OKX.Net.Clients.UnifiedApi
                 limit: pageParams.Limit,
                 toId: pageParams.FromId,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedSpotOrder[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedSpotOrder[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                          () => Pagination.NextPageFromId(result.Data.Min(x => x.OrderId!.Value)),
@@ -432,10 +421,7 @@ namespace OKX.Net.Clients.UnifiedApi
                          pageParams,
                          maxAge: TimeSpan.FromDays(90));
 
-            return result.AsExchangeResult(
-                Exchange,
-                request.Symbol.TradingMode,
-                ExchangeHelpers.ApplyFilter(result.Data, x => x.CreateTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                 .Select(x => 
                     new SharedSpotOrder(
                         ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
@@ -459,22 +445,22 @@ namespace OKX.Net.Clients.UnifiedApi
                 .ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<GetOrderTradesRequest> ISpotOrderRestClient.GetSpotOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest>(true);
-        async Task<ExchangeWebResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
+        GetSpotOrderTradesOptions ISpotOrderRestClient.GetSpotOrderTradesOptions { get; } = new GetSpotOrderTradesOptions(_exchangeName, true);
+        async Task<HttpResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotOrderTradesOptions.ValidateRequest(Exchange, request, request.TradingMode, new[] { TradingMode.Spot });
+            var validationError = SharedClient.GetSpotOrderTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, ArgumentError.Invalid(nameof(GetOrderTradesRequest), "Invalid order id"));
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, ArgumentError.Invalid(nameof(GetOrderTradesRequest), "Invalid order id"));
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var order = await Trading.GetUserTradesAsync(InstrumentType.Spot, symbol, orderId: orderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(order);
 
-            return order.AsExchangeResult<SharedUserTrade[]>(Exchange, TradingMode.Spot, order.Data.Select(x => new SharedUserTrade(
+            return HttpResult.Ok(order, order.Data.Select(x => new SharedUserTrade(
                 ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString()!,
@@ -491,15 +477,15 @@ namespace OKX.Net.Clients.UnifiedApi
             }).ToArray());
         }
 
-        GetUserTradesOptions ISpotOrderRestClient.GetSpotUserTradesOptions { get; } = new GetUserTradesOptions(false, true, true, 100)
+        GetSpotUserTradesOptions ISpotOrderRestClient.GetSpotUserTradesOptions { get; } = new GetSpotUserTradesOptions(_exchangeName, false, true, true, 100)
         {
             MaxAge = TimeSpan.FromDays(3)
         };
-        async Task<ExchangeWebResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedUserTrade[]>> ISpotOrderRestClient.GetSpotUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotUserTradesOptions.ValidateRequest(Exchange, request, request.TradingMode, new[] { TradingMode.Spot });
+            var validationError = SharedClient.GetSpotUserTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
             // Determine page token
             int limit = request.Limit ?? 100;
@@ -516,8 +502,8 @@ namespace OKX.Net.Clients.UnifiedApi
                 limit: pageParams.Limit,
                 fromId: pageParams.FromId,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                          () => Pagination.NextPageFromId(result.Data.Min(x => x.OrderId!.Value)),
@@ -528,10 +514,7 @@ namespace OKX.Net.Clients.UnifiedApi
                          pageParams,
                          maxAge: TimeSpan.FromDays(3));
 
-            return result.AsExchangeResult(
-                Exchange,
-                request.Symbol.TradingMode,
-                ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
                 .Select(x =>
                     new SharedUserTrade(
                         ExchangeSymbolCache.ParseSymbol(_topicSpotId, x.Symbol), 
@@ -550,21 +533,21 @@ namespace OKX.Net.Clients.UnifiedApi
                     }).ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<CancelOrderRequest> ISpotOrderRestClient.CancelSpotOrderOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> ISpotOrderRestClient.CancelSpotOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelSpotOrderOptions ISpotOrderRestClient.CancelSpotOrderOptions { get; } = new CancelSpotOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> ISpotOrderRestClient.CancelSpotOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).CancelSpotOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, new[] { TradingMode.Spot });
+            var validationError = SharedClient.CancelSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest), "Invalid order id"));
+                return HttpResult.Fail<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest), "Invalid order id"));
 
             var order = await Trading.CancelOrderAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(request.OrderId));
+            return HttpResult.Ok(order, new SharedId(request.OrderId));
         }
 
         private OrderType GetPlaceOrderType(SharedOrderType type, SharedTimeInForce? tif)
@@ -612,21 +595,21 @@ namespace OKX.Net.Clients.UnifiedApi
 
         #region Asset client
 
-        EndpointOptions<GetAssetRequest> IAssetsRestClient.GetAssetOptions { get; } = new EndpointOptions<GetAssetRequest>(false);
-        async Task<ExchangeWebResult<SharedAsset>> IAssetsRestClient.GetAssetAsync(GetAssetRequest request, CancellationToken ct)
+        GetAssetOptions IAssetsRestClient.GetAssetOptions { get; } = new GetAssetOptions(_exchangeName, false);
+        async Task<HttpResult<SharedAsset>> IAssetsRestClient.GetAssetAsync(GetAssetRequest request, CancellationToken ct)
         {
-            var validationError = ((IAssetsRestClient)this).GetAssetOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetAssetOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedAsset>(Exchange, validationError);
+                return HttpResult.Fail<SharedAsset>(Exchange, validationError);
 
             var assets = await Account.GetAssetsAsync(request.Asset, ct: ct).ConfigureAwait(false);
-            if (!assets)
-                return assets.AsExchangeResult<SharedAsset>(Exchange, null, default);
+            if (!assets.Success)
+                return HttpResult.Fail<SharedAsset>(assets);
 
             if (!assets.Data.Any())
-                return assets.AsExchangeError<SharedAsset>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownAsset, "Asset not found")));
+                return HttpResult.Fail<SharedAsset>(Exchange, new ServerError(new ErrorInfo(ErrorType.UnknownAsset, "Asset not found")));
 
-            return assets.AsExchangeResult<SharedAsset>(Exchange, TradingMode.Spot, new SharedAsset(request.Asset)
+            return HttpResult.Ok(assets, new SharedAsset(request.Asset)
             {
                 FullName = assets.Data.First().Name,
                 Networks = assets.Data.Select(x => new SharedAssetNetwork(x.Network)
@@ -641,18 +624,18 @@ namespace OKX.Net.Clients.UnifiedApi
             });
         }
 
-        EndpointOptions<GetAssetsRequest> IAssetsRestClient.GetAssetsOptions { get; } = new EndpointOptions<GetAssetsRequest>(true);
-        async Task<ExchangeWebResult<SharedAsset[]>> IAssetsRestClient.GetAssetsAsync(GetAssetsRequest request, CancellationToken ct)
+        GetAssetsOptions IAssetsRestClient.GetAssetsOptions { get; } = new GetAssetsOptions(_exchangeName, true);
+        async Task<HttpResult<SharedAsset[]>> IAssetsRestClient.GetAssetsAsync(GetAssetsRequest request, CancellationToken ct)
         {
-            var validationError = ((IAssetsRestClient)this).GetAssetsOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetAssetsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedAsset[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedAsset[]>(Exchange, validationError);
 
             var assets = await Account.GetAssetsAsync(ct: ct).ConfigureAwait(false);
-            if (!assets)
-                return assets.AsExchangeResult<SharedAsset[]>(Exchange, null, default);
+            if (!assets.Success)
+                return HttpResult.Fail<SharedAsset[]>(assets);
 
-            return assets.AsExchangeResult<SharedAsset[]>(Exchange, TradingMode.Spot, assets.Data.GroupBy(x => x.Asset).Select(x => new SharedAsset(x.Key)
+            return HttpResult.Ok(assets, assets.Data.GroupBy(x => x.Asset).Select(x => new SharedAsset(x.Key)
             {
                 FullName = x.First().Name,
                 Networks = x.Select(x => new SharedAssetNetwork(x.Network)
@@ -670,39 +653,39 @@ namespace OKX.Net.Clients.UnifiedApi
         #endregion
 
         #region Order Book client
-        GetOrderBookOptions IOrderBookRestClient.GetOrderBookOptions { get; } = new GetOrderBookOptions(1, 400, false);
-        async Task<ExchangeWebResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
+        GetOrderBookOptions IOrderBookRestClient.GetOrderBookOptions { get; } = new GetOrderBookOptions(_exchangeName, 1, 400, false);
+        async Task<HttpResult<SharedOrderBook>> IOrderBookRestClient.GetOrderBookAsync(GetOrderBookRequest request, CancellationToken ct)
         {
-            var validationError = ((IOrderBookRestClient)this).GetOrderBookOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetOrderBookOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedOrderBook>(Exchange, validationError);
+                return HttpResult.Fail<SharedOrderBook>(Exchange, validationError);
 
             var result = await ExchangeData.GetOrderBookAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
                 depth: request.Limit ?? 20,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedOrderBook>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedOrderBook>(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedOrderBook(result.Data.Asks, result.Data.Bids));
+            return HttpResult.Ok(result, new SharedOrderBook(result.Data.Asks, result.Data.Bids));
         }
 
         #endregion
 
         #region Deposit client
 
-        EndpointOptions<GetDepositAddressesRequest> IDepositRestClient.GetDepositAddressesOptions { get; } = new EndpointOptions<GetDepositAddressesRequest>(true);
-        async Task<ExchangeWebResult<SharedDepositAddress[]>> IDepositRestClient.GetDepositAddressesAsync(GetDepositAddressesRequest request, CancellationToken ct)
+        GetDepositAddressesOptions IDepositRestClient.GetDepositAddressesOptions { get; } = new GetDepositAddressesOptions(_exchangeName, true);
+        async Task<HttpResult<SharedDepositAddress[]>> IDepositRestClient.GetDepositAddressesAsync(GetDepositAddressesRequest request, CancellationToken ct)
         {
-            var validationError = ((IDepositRestClient)this).GetDepositAddressesOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetDepositAddressesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedDepositAddress[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedDepositAddress[]>(Exchange, validationError);
 
             var depositAddresses = await Account.GetDepositAddressAsync(request.Asset, ct: ct).ConfigureAwait(false);
-            if (!depositAddresses)
-                return depositAddresses.AsExchangeResult<SharedDepositAddress[]>(Exchange, null, default);
+            if (!depositAddresses.Success)
+                return HttpResult.Fail<SharedDepositAddress[]>(depositAddresses);
 
-            return depositAddresses.AsExchangeResult<SharedDepositAddress[]>(Exchange, TradingMode.Spot, depositAddresses.Data.Where(x => request.Network == null ? true : x.Network == request.Network).Select(x => new SharedDepositAddress(request.Asset, x.Address)
+            return HttpResult.Ok(depositAddresses, depositAddresses.Data.Where(x => request.Network == null ? true : x.Network == request.Network).Select(x => new SharedDepositAddress(request.Asset, x.Address)
             {
                 TagOrMemo = x.Memo,
                 Network = x.Network
@@ -710,12 +693,12 @@ namespace OKX.Net.Clients.UnifiedApi
             ).ToArray());
         }
 
-        GetDepositsOptions IDepositRestClient.GetDepositsOptions { get; } = new GetDepositsOptions(false, true, true, 100);
-        async Task<ExchangeWebResult<SharedDeposit[]>> IDepositRestClient.GetDepositsAsync(GetDepositsRequest request, PageRequest? pageRequest, CancellationToken ct)
+        GetDepositsOptions IDepositRestClient.GetDepositsOptions { get; } = new GetDepositsOptions(_exchangeName, false, true, true, 100);
+        async Task<HttpResult<SharedDeposit[]>> IDepositRestClient.GetDepositsAsync(GetDepositsRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IDepositRestClient)this).GetDepositsOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetDepositsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedDeposit[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedDeposit[]>(Exchange, validationError);
 
             // Determine page token
             int limit = request.Limit ?? 100;
@@ -729,8 +712,8 @@ namespace OKX.Net.Clients.UnifiedApi
                 endTime: pageParams.EndTime,
                 limit: pageParams.Limit,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedDeposit[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedDeposit[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                          () => Pagination.NextPageFromTime(pageParams, result.Data.Min(x => x.Time)),
@@ -740,10 +723,7 @@ namespace OKX.Net.Clients.UnifiedApi
                          request.EndTime ?? DateTime.UtcNow,
                          pageParams);
 
-            return result.AsExchangeResult(
-                Exchange,
-                TradingMode.Spot,
-                ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
                 .Select(x => 
                     new SharedDeposit(
                         x.Asset,
@@ -775,12 +755,12 @@ namespace OKX.Net.Clients.UnifiedApi
 
         #region Withdrawal client
 
-        GetWithdrawalsOptions IWithdrawalRestClient.GetWithdrawalsOptions { get; } = new GetWithdrawalsOptions(false, true, true, 100);
-        async Task<ExchangeWebResult<SharedWithdrawal[]>> IWithdrawalRestClient.GetWithdrawalsAsync(GetWithdrawalsRequest request, PageRequest? pageRequest, CancellationToken ct)
+        GetWithdrawalsOptions IWithdrawalRestClient.GetWithdrawalsOptions { get; } = new GetWithdrawalsOptions(_exchangeName, false, true, true, 100);
+        async Task<HttpResult<SharedWithdrawal[]>> IWithdrawalRestClient.GetWithdrawalsAsync(GetWithdrawalsRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IWithdrawalRestClient)this).GetWithdrawalsOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.GetWithdrawalsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedWithdrawal[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedWithdrawal[]>(Exchange, validationError);
 
             // Determine page token
             int limit = request.Limit ?? 100;
@@ -794,8 +774,8 @@ namespace OKX.Net.Clients.UnifiedApi
                 endTime: pageParams.EndTime,
                 limit: pageParams.Limit,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedWithdrawal[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedWithdrawal[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                          () => Pagination.NextPageFromTime(pageParams, result.Data.Min(x => x.Time)),
@@ -805,10 +785,7 @@ namespace OKX.Net.Clients.UnifiedApi
                          request.EndTime ?? DateTime.UtcNow,
                          pageParams);
 
-            return result.AsExchangeResult(
-                Exchange,
-                TradingMode.Spot,
-                ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
                 .Select(x =>
                     new SharedWithdrawal(x.Asset, x.To, x.Quantity, x.State == WithdrawalState.Success, x.Time)
                     {
@@ -823,19 +800,18 @@ namespace OKX.Net.Clients.UnifiedApi
 
         #region Withdraw client
 
-        WithdrawOptions IWithdrawRestClient.WithdrawOptions { get; } = new WithdrawOptions
-        {
+        WithdrawOptions IWithdrawRestClient.WithdrawOptions { get; } = new WithdrawOptions(_exchangeName) {
             RequiredExchangeParameters = new List<ParameterDescription>
             {
                 new ParameterDescription("withdrawFee", typeof(decimal), "Fee to use for the withdrawal", 0.001m)
             }
         };
 
-        async Task<ExchangeWebResult<SharedId>> IWithdrawRestClient.WithdrawAsync(WithdrawRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IWithdrawRestClient.WithdrawAsync(WithdrawRequest request, CancellationToken ct)
         {
-            var validationError = ((IWithdrawRestClient)this).WithdrawOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.WithdrawOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var target = request.Address;
             if (request.AddressTag != null)
@@ -852,27 +828,27 @@ namespace OKX.Net.Clients.UnifiedApi
                 fee,
                 network: request.Network,
                 ct: ct).ConfigureAwait(false);
-            if (!withdrawal)
-                return withdrawal.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!withdrawal.Success)
+                return HttpResult.Fail<SharedId>(withdrawal);
 
-            return withdrawal.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(withdrawal.Data.WithdrawalId));
+            return HttpResult.Ok(withdrawal, new SharedId(withdrawal.Data.WithdrawalId));
         }
 
         #endregion
 
         #region Futures Symbol client
 
-        EndpointOptions<GetSymbolsRequest> IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new EndpointOptions<GetSymbolsRequest>(false);
-        async Task<ExchangeWebResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
+        GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
+        async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesSymbolRestClient)this).GetFuturesSymbolsOptions.ValidateRequest(Exchange, request, request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.GetFuturesSymbolsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesSymbol[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesSymbol[]>(Exchange, validationError);
 
             var type = (!request.TradingMode.HasValue || request.TradingMode == TradingMode.PerpetualLinear || request.TradingMode == TradingMode.PerpetualInverse) ? InstrumentType.Swap : InstrumentType.Futures;
             var result = await ExchangeData.GetSymbolsAsync(type, ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFuturesSymbol[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFuturesSymbol[]>(result);
 
             IEnumerable<OKXInstrument> data = result.Data;
             if (request.TradingMode.HasValue)
@@ -882,8 +858,7 @@ namespace OKX.Net.Clients.UnifiedApi
                     request.TradingMode == TradingMode.DeliveryLinear ? (x.ContractType == ContractType.Linear && x.ExpiryTime != null) :
                     (x.ContractType == ContractType.Inverse && x.ExpiryTime != null));
             
-            var response = result.AsExchangeResult<SharedFuturesSymbol[]>(Exchange,
-                request.TradingMode == null ? FuturesApiTypes : new[] { request.TradingMode.Value },
+            var response = HttpResult.Ok(result,
                 data.Select(x => new SharedFuturesSymbol(
                 x.ContractType == ContractType.Linear ? TradingMode.PerpetualLinear : TradingMode.PerpetualInverse,
                 x.Symbol.Split('-')[0],
@@ -902,23 +877,23 @@ namespace OKX.Net.Clients.UnifiedApi
                 }).ToArray());
 
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, response.Data);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, response.Data!);
             return response;
         }
 
-        async Task<ExchangeResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
+        async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
         {
             if (!ExchangeSymbolCache.HasCached(_topicFuturesId))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<SharedSymbol[]>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<SharedSymbol[]>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<SharedSymbol[]>(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicFuturesId, baseAsset));
+            return ExchangeCallResult<SharedSymbol[]>.Ok(Exchange, ExchangeSymbolCache.GetSymbolsForBaseAsset(_topicFuturesId, baseAsset));
         }
 
-        async Task<ExchangeResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(SharedSymbol symbol)
+        async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(SharedSymbol symbol)
         {
             if (symbol.TradingMode == TradingMode.Spot)
                 throw new ArgumentException(nameof(symbol), "Spot symbols not allowed");
@@ -926,23 +901,23 @@ namespace OKX.Net.Clients.UnifiedApi
             if (!ExchangeSymbolCache.HasCached(_topicFuturesId))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, symbol));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, symbol));
         }
 
-        async Task<ExchangeResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(string symbolName)
+        async Task<ExchangeCallResult<bool>> IFuturesSymbolRestClient.SupportsFuturesSymbolAsync(string symbolName)
         {
             if (!ExchangeSymbolCache.HasCached(_topicFuturesId))
             {
                 var symbols = await ((IFuturesSymbolRestClient)this).GetFuturesSymbolsAsync(new GetSymbolsRequest()).ConfigureAwait(false);
-                if (!symbols)
-                    return new ExchangeResult<bool>(Exchange, symbols.Error!);
+                if (!symbols.Success)
+                    return ExchangeCallResult<bool>.Fail(Exchange, symbols.Error!);
             }
 
-            return new ExchangeResult<bool>(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, symbolName));
+            return ExchangeCallResult<bool>.Ok(Exchange, ExchangeSymbolCache.SupportsSymbol(_topicFuturesId, symbolName));
         }
         #endregion
 
@@ -960,25 +935,18 @@ namespace OKX.Net.Clients.UnifiedApi
 
         string IFuturesOrderRestClient.GenerateClientOrderId() => ExchangeHelpers.RandomString(32);
 
-        PlaceFuturesOrderOptions IFuturesOrderRestClient.PlaceFuturesOrderOptions { get; } = new PlaceFuturesOrderOptions(false)
+        PlaceFuturesOrderOptions IFuturesOrderRestClient.PlaceFuturesOrderOptions { get; } = new PlaceFuturesOrderOptions(_exchangeName, false)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
                 new ParameterDescription(nameof(PlaceFuturesOrderRequest.MarginMode), typeof(SharedMarginMode), "Isolated or cross margin", SharedMarginMode.Cross)
             }
         };
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.PlaceFuturesOrderAsync(PlaceFuturesOrderRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IFuturesOrderRestClient.PlaceFuturesOrderAsync(PlaceFuturesOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).PlaceFuturesOrderOptions.ValidateRequest(
-                Exchange,
-                request,
-                request.TradingMode,
-                SupportedTradingModes,
-                ((IFuturesOrderRestClient)this).FuturesSupportedOrderTypes,
-                ((IFuturesOrderRestClient)this).FuturesSupportedTimeInForce,
-                ((IFuturesOrderRestClient)this).FuturesSupportedOrderQuantity);
+            var validationError = SharedClient.PlaceFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await Trading.PlaceOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -992,27 +960,27 @@ namespace OKX.Net.Clients.UnifiedApi
                 clientOrderId: request.ClientOrderId,
                 ct: ct).ConfigureAwait(false);
 
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(result.Data.OrderId.ToString()!));
+            return HttpResult.Ok(result, new SharedId(result.Data.OrderId.ToString()!));
         }
 
-        EndpointOptions<GetOrderRequest> IFuturesOrderRestClient.GetFuturesOrderOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedFuturesOrder>> IFuturesOrderRestClient.GetFuturesOrderAsync(GetOrderRequest request, CancellationToken ct)
+        GetFuturesOrderOptions IFuturesOrderRestClient.GetFuturesOrderOptions { get; } = new GetFuturesOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedFuturesOrder>> IFuturesOrderRestClient.GetFuturesOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.GetFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesOrder>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedFuturesOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderRequest), "Invalid order id"));
+                return HttpResult.Fail<SharedFuturesOrder>(Exchange, ArgumentError.Invalid(nameof(GetOrderRequest), "Invalid order id"));
 
             var order = await Trading.GetOrderDetailsAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedFuturesOrder>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedFuturesOrder>(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedFuturesOrder(
+            return HttpResult.Ok(order, new SharedFuturesOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicFuturesId, order.Data.Symbol), 
                 order.Data.Symbol,
                 order.Data.OrderId.ToString()!,
@@ -1038,25 +1006,25 @@ namespace OKX.Net.Clients.UnifiedApi
             });
         }
 
-        EndpointOptions<GetOpenOrdersRequest> IFuturesOrderRestClient.GetOpenFuturesOrdersOptions { get; } = new EndpointOptions<GetOpenOrdersRequest>(true);
-        async Task<ExchangeWebResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetOpenFuturesOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
+        GetOpenFuturesOrdersOptions IFuturesOrderRestClient.GetOpenFuturesOrdersOptions { get; } = new GetOpenFuturesOrdersOptions(_exchangeName, true);
+        async Task<HttpResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetOpenFuturesOrdersAsync(GetOpenOrdersRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetOpenFuturesOrdersOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.GetOpenFuturesOrdersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesOrder[]>(Exchange, validationError);
 
             var symbol = request.Symbol?.GetSymbol(FormatSymbol);
             var tradingMode = request.Symbol?.TradingMode ?? request.TradingMode ?? TradingMode.PerpetualLinear;
-            WebCallResult<OKXOrder[]> orders;
+            HttpResult<OKXOrder[]> orders;
             if (tradingMode.IsPerpetual())
                 orders = await Trading.GetOrdersAsync(InstrumentType.Swap, symbol: symbol, ct: ct).ConfigureAwait(false);
             else
                 orders = await Trading.GetOrdersAsync(InstrumentType.Futures, symbol: symbol, ct: ct).ConfigureAwait(false);
 
-            if (!orders)
-                return orders.AsExchangeResult<SharedFuturesOrder[]>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedFuturesOrder[]>(orders);
 
-            return orders.AsExchangeResult<SharedFuturesOrder[]>(Exchange, request.Symbol == null ? SupportedTradingModes : new[] { request.Symbol.TradingMode }, orders.Data.Select(x => new SharedFuturesOrder(
+            return HttpResult.Ok(orders, orders.Data.Select(x => new SharedFuturesOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString()!,
@@ -1082,15 +1050,15 @@ namespace OKX.Net.Clients.UnifiedApi
             }).ToArray());
         }
 
-        GetClosedOrdersOptions IFuturesOrderRestClient.GetClosedFuturesOrdersOptions { get; } = new GetClosedOrdersOptions(false, true, true, 100)
+        GetFuturesClosedOrdersOptions IFuturesOrderRestClient.GetClosedFuturesOrdersOptions { get; } = new GetFuturesClosedOrdersOptions(_exchangeName, false, true, true, 100)
         {
             MaxAge = TimeSpan.FromDays(90)
         };
-        async Task<ExchangeWebResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetClosedFuturesOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedFuturesOrder[]>> IFuturesOrderRestClient.GetClosedFuturesOrdersAsync(GetClosedOrdersRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetClosedFuturesOrdersOptions.ValidateRequest(Exchange, request, request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.GetClosedFuturesOrdersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesOrder[]>(Exchange, validationError);
 
             // Determine page token
             int limit = request.Limit ?? 100;
@@ -1099,7 +1067,7 @@ namespace OKX.Net.Clients.UnifiedApi
 
             // Get data
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
-            WebCallResult<OKXOrder[]> result;
+            HttpResult<OKXOrder[]> result;
             if (request.Symbol.TradingMode.IsPerpetual())
             {
                 result = await Trading.GetOrderArchiveAsync(
@@ -1123,8 +1091,8 @@ namespace OKX.Net.Clients.UnifiedApi
                     ct: ct).ConfigureAwait(false);
             }
 
-            if (!result)
-                return result.AsExchangeResult<SharedFuturesOrder[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFuturesOrder[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                          () => Pagination.NextPageFromId(result.Data.Min(x => x.OrderId!.Value)),
@@ -1135,10 +1103,7 @@ namespace OKX.Net.Clients.UnifiedApi
                          pageParams,
                          TimeSpan.FromDays(90));
 
-            return result.AsExchangeResult(
-                Exchange,
-                request.Symbol.TradingMode,
-                ExchangeHelpers.ApplyFilter(result.Data, x => x.CreateTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                 .Select(x => 
                     new SharedFuturesOrder(
                         ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
@@ -1167,18 +1132,18 @@ namespace OKX.Net.Clients.UnifiedApi
                 .ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<GetOrderTradesRequest> IFuturesOrderRestClient.GetFuturesOrderTradesOptions { get; } = new EndpointOptions<GetOrderTradesRequest>(true);
-        async Task<ExchangeWebResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
+        GetFuturesOrderTradesOptions IFuturesOrderRestClient.GetFuturesOrderTradesOptions { get; } = new GetFuturesOrderTradesOptions(_exchangeName, true);
+        async Task<HttpResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesOrderTradesAsync(GetOrderTradesRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesOrderTradesOptions.ValidateRequest(Exchange, request, request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.GetFuturesOrderTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, ArgumentError.Invalid(nameof(GetOrderTradesRequest), "Invalid order id"));
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, ArgumentError.Invalid(nameof(GetOrderTradesRequest), "Invalid order id"));
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
-            WebCallResult<OKXTransaction[]> orders;
+            HttpResult<OKXTransaction[]> orders;
             if (request.Symbol.TradingMode.IsPerpetual())
             {
                 orders = await Trading.GetUserTradesArchiveAsync(
@@ -1196,10 +1161,10 @@ namespace OKX.Net.Clients.UnifiedApi
                     ct: ct).ConfigureAwait(false);
             }
 
-            if (!orders)
-                return orders.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+            if (!orders.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(orders);
 
-            return orders.AsExchangeResult<SharedUserTrade[]>(Exchange, request.Symbol.TradingMode, orders.Data.Select(x => new SharedUserTrade(
+            return HttpResult.Ok(orders, orders.Data.Select(x => new SharedUserTrade(
                 ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
                 x.Symbol,
                 x.OrderId.ToString()!,
@@ -1216,15 +1181,15 @@ namespace OKX.Net.Clients.UnifiedApi
             }).ToArray());
         }
 
-        GetUserTradesOptions IFuturesOrderRestClient.GetFuturesUserTradesOptions { get; } = new GetUserTradesOptions(false, true, true, 100)
+        GetFuturesUserTradesOptions IFuturesOrderRestClient.GetFuturesUserTradesOptions { get; } = new GetFuturesUserTradesOptions(_exchangeName, false, true, true, 100)
         {
             MaxAge = TimeSpan.FromDays(3)
         };
-        async Task<ExchangeWebResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedUserTrade[]>> IFuturesOrderRestClient.GetFuturesUserTradesAsync(GetUserTradesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesUserTradesOptions.ValidateRequest(Exchange, request, request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.GetFuturesUserTradesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedUserTrade[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedUserTrade[]>(Exchange, validationError);
 
             // Determine page token
             int limit = request.Limit ?? 100;
@@ -1233,7 +1198,7 @@ namespace OKX.Net.Clients.UnifiedApi
 
             // Get data
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
-            WebCallResult<OKXTransaction[]> result;
+            HttpResult<OKXTransaction[]> result;
             if (request.Symbol.TradingMode.IsPerpetual())
             {
                 result = await Trading.GetUserTradesAsync(
@@ -1258,8 +1223,8 @@ namespace OKX.Net.Clients.UnifiedApi
                     ct: ct
                 ).ConfigureAwait(false);
             }
-            if (!result)
-                return result.AsExchangeResult<SharedUserTrade[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedUserTrade[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                          () => Pagination.NextPageFromId(result.Data.Min(x => x.OrderId!.Value)),
@@ -1270,10 +1235,7 @@ namespace OKX.Net.Clients.UnifiedApi
                          pageParams,
                          maxAge: TimeSpan.FromDays(3));
 
-            return result.AsExchangeResult(
-                Exchange,
-                request.Symbol.TradingMode,
-                ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
                 .Select(x => 
                     new SharedUserTrade(
                         ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
@@ -1293,35 +1255,35 @@ namespace OKX.Net.Clients.UnifiedApi
                 .ToArray(), nextPageRequest);
         }
 
-        EndpointOptions<CancelOrderRequest> IFuturesOrderRestClient.CancelFuturesOrderOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.CancelFuturesOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelFuturesOrderOptions IFuturesOrderRestClient.CancelFuturesOrderOptions { get; } = new CancelFuturesOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> IFuturesOrderRestClient.CancelFuturesOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).CancelFuturesOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.CancelFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             if (!long.TryParse(request.OrderId, out var orderId))
-                return new ExchangeWebResult<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest), "Invalid order id"));
+                return HttpResult.Fail<SharedId>(Exchange, ArgumentError.Invalid(nameof(CancelOrderRequest), "Invalid order id"));
 
             var order = await Trading.CancelOrderAsync(request.Symbol!.GetSymbol(FormatSymbol), orderId).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(order.Data.OrderId.ToString()!));
+            return HttpResult.Ok(order, new SharedId(order.Data.OrderId.ToString()!));
         }
 
-        EndpointOptions<GetPositionsRequest> IFuturesOrderRestClient.GetPositionsOptions { get; } = new EndpointOptions<GetPositionsRequest>(true);
-        async Task<ExchangeWebResult<SharedPosition[]>> IFuturesOrderRestClient.GetPositionsAsync(GetPositionsRequest request, CancellationToken ct)
+        GetPositionsOptions IFuturesOrderRestClient.GetPositionsOptions { get; } = new GetPositionsOptions(_exchangeName, true);
+        async Task<HttpResult<SharedPosition[]>> IFuturesOrderRestClient.GetPositionsAsync(GetPositionsRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetPositionsOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.GetPositionsOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedPosition[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedPosition[]>(Exchange, validationError);
 
             var result = await Account.GetPositionsAsync(symbol: request.Symbol?.GetSymbol(FormatSymbol), ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedPosition[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedPosition[]>(result);
 
-            return result.AsExchangeResult<SharedPosition[]>(Exchange, request.Symbol == null ? SupportedTradingModes : new[] { request.Symbol.TradingMode }, result.Data.Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), x.Symbol, Math.Abs(x.PositionsQuantity ?? 0), x.UpdateTime)
+            return HttpResult.Ok(result, result.Data.Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), x.Symbol, Math.Abs(x.PositionsQuantity ?? 0), x.UpdateTime)
             {
                 UnrealizedPnl = x.UnrealizedPnl,
                 LiquidationPrice = x.LiquidationPrice,
@@ -1334,7 +1296,7 @@ namespace OKX.Net.Clients.UnifiedApi
             }).ToArray());
         }
 
-        EndpointOptions<ClosePositionRequest> IFuturesOrderRestClient.ClosePositionOptions { get; } = new EndpointOptions<ClosePositionRequest>(true)
+        ClosePositionOptions IFuturesOrderRestClient.ClosePositionOptions { get; } = new ClosePositionOptions(_exchangeName, true)
         {
             RequestNotes = "No order id returned by the API for this",
             RequiredOptionalParameters = new List<ParameterDescription>
@@ -1342,21 +1304,21 @@ namespace OKX.Net.Clients.UnifiedApi
                 new ParameterDescription(nameof(ClosePositionRequest.MarginMode), typeof(SharedMarginMode), "Cross or isolated margin position", SharedMarginMode.Cross)
             }
         };
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderRestClient.ClosePositionAsync(ClosePositionRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IFuturesOrderRestClient.ClosePositionAsync(ClosePositionRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).ClosePositionOptions.ValidateRequest(Exchange, request, request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.ClosePositionOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await Trading.ClosePositionAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
                 request.MarginMode == SharedMarginMode.Cross ? MarginMode.Cross : MarginMode.Isolated,
                 positionSide: request.PositionSide == null ? null : request.PositionSide == SharedPositionSide.Short ? PositionSide.Short : PositionSide.Long,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(string.Empty));
+            return HttpResult.Ok(result, new SharedId(string.Empty));
         }
 
         #endregion
@@ -1364,49 +1326,48 @@ namespace OKX.Net.Clients.UnifiedApi
         #region Leverage client
         SharedLeverageSettingMode ILeverageRestClient.LeverageSettingType => SharedLeverageSettingMode.PerSide;
 
-        EndpointOptions<GetLeverageRequest> ILeverageRestClient.GetLeverageOptions { get; } = new EndpointOptions<GetLeverageRequest>(true)
+        GetLeverageOptions ILeverageRestClient.GetLeverageOptions { get; } = new GetLeverageOptions(_exchangeName, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
                 new ParameterDescription(nameof(GetLeverageRequest.MarginMode), typeof(SharedMarginMode), "Cross or isolated margin", SharedMarginMode.Cross)
             }
         };
-        async Task<ExchangeWebResult<SharedLeverage>> ILeverageRestClient.GetLeverageAsync(GetLeverageRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedLeverage>> ILeverageRestClient.GetLeverageAsync(GetLeverageRequest request, CancellationToken ct)
         {
-            var validationError = ((ILeverageRestClient)this).GetLeverageOptions.ValidateRequest(Exchange, request, request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.GetLeverageOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedLeverage>(Exchange, validationError);
+                return HttpResult.Fail<SharedLeverage>(Exchange, validationError);
 
             var result = await Account.GetLeverageAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
                 request.MarginMode == SharedMarginMode.Cross ? MarginMode.Cross : MarginMode.Isolated,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedLeverage>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedLeverage>(result);
 
             var side = request.PositionSide == null ? result.Data.First() : result.Data.FirstOrDefault(d => d.PositionSide == (request.PositionSide == SharedPositionSide.Short ? PositionSide.Short : PositionSide.Long));
             if (side == null)
-                return result.AsExchangeError<SharedLeverage>(Exchange, new ServerError(new ErrorInfo(ErrorType.NoPosition, "Position not found")));
+                return HttpResult.Fail<SharedLeverage>(Exchange, new ServerError(new ErrorInfo(ErrorType.NoPosition, "Position not found")));
             
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedLeverage(side.Leverage ?? 0)
+            return HttpResult.Ok(result, new SharedLeverage(side.Leverage ?? 0)
             {
                 MarginMode = side.MarginMode == MarginMode.Isolated ? SharedMarginMode.Isolated : SharedMarginMode.Cross,
                 Side = side.PositionSide == PositionSide.Net ? null : side.PositionSide == PositionSide.Long ? SharedPositionSide.Long : SharedPositionSide.Short
             });
         }
 
-        SetLeverageOptions ILeverageRestClient.SetLeverageOptions { get; } = new SetLeverageOptions
-        {
+        SetLeverageOptions ILeverageRestClient.SetLeverageOptions { get; } = new SetLeverageOptions(_exchangeName) {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
                 new ParameterDescription(nameof(GetLeverageRequest.MarginMode), typeof(SharedMarginMode), "Cross or isolated margin", SharedMarginMode.Cross)
             }
         };
-        async Task<ExchangeWebResult<SharedLeverage>> ILeverageRestClient.SetLeverageAsync(SetLeverageRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedLeverage>> ILeverageRestClient.SetLeverageAsync(SetLeverageRequest request, CancellationToken ct)
         {
-            var validationError = ((ILeverageRestClient)this).SetLeverageOptions.ValidateRequest(Exchange, request, request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.SetLeverageOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedLeverage>(Exchange, validationError);
+                return HttpResult.Fail<SharedLeverage>(Exchange, validationError);
 
             var result = await Account.SetLeverageAsync(
                 (int)request.Leverage,
@@ -1414,10 +1375,10 @@ namespace OKX.Net.Clients.UnifiedApi
                 symbol: request.Symbol!.GetSymbol(FormatSymbol),
                 positionSide: request.Side == null ? null : request.Side == SharedPositionSide.Short ? PositionSide.Short : PositionSide.Long,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedLeverage>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedLeverage>(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedLeverage(result.Data.First().Leverage ?? 0)
+            return HttpResult.Ok(result, new SharedLeverage(result.Data.First().Leverage ?? 0)
             {
                 Side = request.Side
             });
@@ -1426,17 +1387,15 @@ namespace OKX.Net.Clients.UnifiedApi
 
         #region Index Klines client
 
-        GetKlinesOptions IIndexPriceKlineRestClient.GetIndexPriceKlinesOptions { get; } = new GetKlinesOptions(false, true, true, 100, false);
+        GetIndexPriceKlinesOptions IIndexPriceKlineRestClient.GetIndexPriceKlinesOptions { get; } = new GetIndexPriceKlinesOptions(_exchangeName, false, true, true, 100, false);
 
-        async Task<ExchangeWebResult<SharedFuturesKline[]>> IIndexPriceKlineRestClient.GetIndexPriceKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedFuturesKline[]>> IIndexPriceKlineRestClient.GetIndexPriceKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
             var interval = (KlineInterval)request.Interval;
-            if (!Enum.IsDefined(typeof(KlineInterval), interval))
-                return new ExchangeWebResult<SharedFuturesKline[]>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
 
-            var validationError = ((IIndexPriceKlineRestClient)this).GetIndexPriceKlinesOptions.ValidateRequest(Exchange, request, request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.GetIndexPriceKlinesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesKline[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesKline[]>(Exchange, validationError);
 
             int limit = request.Limit ?? 100;
             var direction = DataDirection.Descending;
@@ -1451,8 +1410,8 @@ namespace OKX.Net.Clients.UnifiedApi
                 pageParams.Limit,
                 ct: ct
                 ).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFuturesKline[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFuturesKline[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                      () => Pagination.NextPageFromTime(pageParams, result.Data.Min(x => x.Time)),
@@ -1462,10 +1421,7 @@ namespace OKX.Net.Clients.UnifiedApi
                      request.EndTime ?? DateTime.UtcNow,
                      pageParams);
 
-            return result.AsExchangeResult(
-                    Exchange,
-                    request.Symbol.TradingMode,
-                    ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
                     .Select(x => 
                         new SharedFuturesKline(request.Symbol, symbol, x.Time, x.ClosePrice, x.HighPrice, x.LowPrice, x.OpenPrice))
                     .ToArray(), nextPageRequest);
@@ -1475,17 +1431,15 @@ namespace OKX.Net.Clients.UnifiedApi
 
         #region Mark Klines client
 
-        GetKlinesOptions IMarkPriceKlineRestClient.GetMarkPriceKlinesOptions { get; } = new GetKlinesOptions(false, true, true, 100, false);
+        GetMarkPriceKlinesOptions IMarkPriceKlineRestClient.GetMarkPriceKlinesOptions { get; } = new GetMarkPriceKlinesOptions(_exchangeName, false, true, true, 100, false);
 
-        async Task<ExchangeWebResult<SharedFuturesKline[]>> IMarkPriceKlineRestClient.GetMarkPriceKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedFuturesKline[]>> IMarkPriceKlineRestClient.GetMarkPriceKlinesAsync(GetKlinesRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
             var interval = (KlineInterval)request.Interval;
-            if (!Enum.IsDefined(typeof(KlineInterval), interval))
-                return new ExchangeWebResult<SharedFuturesKline[]>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
 
-            var validationError = ((IMarkPriceKlineRestClient)this).GetMarkPriceKlinesOptions.ValidateRequest(Exchange, request, request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.GetMarkPriceKlinesOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesKline[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesKline[]>(Exchange, validationError);
 
             int limit = request.Limit ?? 100;
             var direction = DataDirection.Descending;
@@ -1500,8 +1454,8 @@ namespace OKX.Net.Clients.UnifiedApi
                 pageParams.Limit,
                 ct: ct
                 ).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFuturesKline[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFuturesKline[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                      () => Pagination.NextPageFromTime(pageParams, result.Data.Min(x => x.Time)),
@@ -1511,10 +1465,7 @@ namespace OKX.Net.Clients.UnifiedApi
                      request.EndTime ?? DateTime.UtcNow,
                      pageParams);
 
-            return result.AsExchangeResult(
-                    Exchange,
-                    request.Symbol.TradingMode,
-                    ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.Time, request.StartTime, request.EndTime, direction)
                     .Select(x => 
                         new SharedFuturesKline(request.Symbol, symbol, x.Time, x.ClosePrice, x.HighPrice, x.LowPrice, x.OpenPrice))
                     .ToArray(), nextPageRequest);
@@ -1524,35 +1475,35 @@ namespace OKX.Net.Clients.UnifiedApi
 
         #region Open Interest client
 
-        EndpointOptions<GetOpenInterestRequest> IOpenInterestRestClient.GetOpenInterestOptions { get; } = new EndpointOptions<GetOpenInterestRequest>(true);
-        async Task<ExchangeWebResult<SharedOpenInterest>> IOpenInterestRestClient.GetOpenInterestAsync(GetOpenInterestRequest request, CancellationToken ct)
+        GetOpenInterestOptions IOpenInterestRestClient.GetOpenInterestOptions { get; } = new GetOpenInterestOptions(_exchangeName, true);
+        async Task<HttpResult<SharedOpenInterest>> IOpenInterestRestClient.GetOpenInterestAsync(GetOpenInterestRequest request, CancellationToken ct)
         {
-            var validationError = ((IOpenInterestRestClient)this).GetOpenInterestOptions.ValidateRequest(Exchange, request, request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.GetOpenInterestOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedOpenInterest>(Exchange, validationError);
+                return HttpResult.Fail<SharedOpenInterest>(Exchange, validationError);
 
-            WebCallResult<OKXOpenInterest[]> result;
+            HttpResult<OKXOpenInterest[]> result;
             if (request.Symbol!.TradingMode.IsPerpetual())
                 result = await ExchangeData.GetOpenInterestsAsync(InstrumentType.Swap, symbol: request.Symbol.GetSymbol(FormatSymbol), ct: ct).ConfigureAwait(false);
             else
                 result = await ExchangeData.GetOpenInterestsAsync(InstrumentType.Futures, symbol: request.Symbol.GetSymbol(FormatSymbol), ct: ct).ConfigureAwait(false);
 
-            if (!result)
-                return result.AsExchangeResult<SharedOpenInterest>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedOpenInterest>(result);
 
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedOpenInterest(result.Data.First().OpenInterest ?? 0));
+            return HttpResult.Ok(result, new SharedOpenInterest(result.Data.First().OpenInterest ?? 0));
         }
 
         #endregion
 
         #region Funding Rate client
-        GetFundingRateHistoryOptions IFundingRateRestClient.GetFundingRateHistoryOptions { get; } = new GetFundingRateHistoryOptions(false, true, true, 400, false);
+        GetFundingRateHistoryOptions IFundingRateRestClient.GetFundingRateHistoryOptions { get; } = new GetFundingRateHistoryOptions(_exchangeName, false, true, true, 400, false);
 
-        async Task<ExchangeWebResult<SharedFundingRate[]>> IFundingRateRestClient.GetFundingRateHistoryAsync(GetFundingRateHistoryRequest request, PageRequest? pageRequest, CancellationToken ct)
+        async Task<HttpResult<SharedFundingRate[]>> IFundingRateRestClient.GetFundingRateHistoryAsync(GetFundingRateHistoryRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IFundingRateRestClient)this).GetFundingRateHistoryOptions.ValidateRequest(Exchange, request, request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.GetFundingRateHistoryOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFundingRate[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFundingRate[]>(Exchange, validationError);
 
             int limit = request.Limit ?? 400;
             var direction = DataDirection.Descending;
@@ -1565,8 +1516,8 @@ namespace OKX.Net.Clients.UnifiedApi
                 endTime: pageParams.EndTime,
                 limit: pageParams.Limit,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFundingRate[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFundingRate[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                      () => Pagination.NextPageFromTime(pageParams, result.Data.Min(x => x.FundingTime)),
@@ -1576,10 +1527,7 @@ namespace OKX.Net.Clients.UnifiedApi
                      request.EndTime ?? DateTime.UtcNow,
                      pageParams);
 
-            return result.AsExchangeResult(
-                    Exchange,
-                    request.Symbol.TradingMode,
-                    ExchangeHelpers.ApplyFilter(result.Data, x => x.FundingTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.FundingTime, request.StartTime, request.EndTime, direction)
                     .Select(x => 
                         new SharedFundingRate(x.FundingRate, x.FundingTime))
                     .ToArray(), nextPageRequest);
@@ -1588,12 +1536,12 @@ namespace OKX.Net.Clients.UnifiedApi
 
         #region Futures Ticker client
 
-        GetTickerOptions IFuturesTickerRestClient.GetFuturesTickerOptions { get; } = new GetTickerOptions();
-        async Task<ExchangeWebResult<SharedFuturesTicker>> IFuturesTickerRestClient.GetFuturesTickerAsync(GetTickerRequest request, CancellationToken ct)
+        GetFuturesTickerOptions IFuturesTickerRestClient.GetFuturesTickerOptions { get; } = new GetFuturesTickerOptions(_exchangeName);
+        async Task<HttpResult<SharedFuturesTicker>> IFuturesTickerRestClient.GetFuturesTickerAsync(GetTickerRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTickerRestClient)this).GetFuturesTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.GetFuturesTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesTicker>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesTicker>(Exchange, validationError);
 
             var symbol = request.Symbol!.GetSymbol(FormatSymbol);
             var resultTicker = ExchangeData.GetTickerAsync(symbol, ct: ct);
@@ -1601,19 +1549,17 @@ namespace OKX.Net.Clients.UnifiedApi
             var resultMarkPrice = ExchangeData.GetMarkPricesAsync(request.Symbol.TradingMode.IsPerpetual() ? InstrumentType.Swap : InstrumentType.Futures, symbol: symbol, ct: ct);
             var resultIndexPrice = ExchangeData.GetIndexTickersAsync(symbol: symbol.Split('-')[0] + "-" + symbol.Split('-')[1], ct: ct);
             await Task.WhenAll(resultTicker, resultFunding).ConfigureAwait(false);
-            if (!resultTicker.Result)
-                return resultTicker.Result.AsExchangeResult<SharedFuturesTicker>(Exchange, null, default);
-            if (!resultIndexPrice.Result)
-                return resultIndexPrice.Result.AsExchangeResult<SharedFuturesTicker>(Exchange, null, default);
-            if (!resultMarkPrice.Result)
-                return resultMarkPrice.Result.AsExchangeResult<SharedFuturesTicker>(Exchange, null, default);
+            if (!resultTicker.Result.Success)
+                return HttpResult.Fail<SharedFuturesTicker>(resultTicker.Result);
+            if (!resultIndexPrice.Result.Success)
+                return HttpResult.Fail<SharedFuturesTicker>(resultIndexPrice.Result);
+            if (!resultMarkPrice.Result.Success)
+                return HttpResult.Fail<SharedFuturesTicker>(resultMarkPrice.Result);
 
             var funding = resultFunding.Result.Data?.SingleOrDefault();
             var index = resultIndexPrice.Result.Data.Single();
             var mark = resultMarkPrice.Result.Data.Single();
-            return resultTicker.Result.AsExchangeResult(Exchange,
-                request.Symbol.TradingMode,
-                new SharedFuturesTicker(
+            return HttpResult.Ok(resultTicker.Result, new SharedFuturesTicker(
                     ExchangeSymbolCache.ParseSymbol(_topicFuturesId, resultTicker.Result.Data.Symbol),
                     resultTicker.Result.Data.Symbol,
                     resultTicker.Result.Data.LastPrice,
@@ -1629,25 +1575,23 @@ namespace OKX.Net.Clients.UnifiedApi
                 });
         }
 
-        GetTickersOptions IFuturesTickerRestClient.GetFuturesTickersOptions { get; } = new GetTickersOptions();
-        async Task<ExchangeWebResult<SharedFuturesTicker[]>> IFuturesTickerRestClient.GetFuturesTickersAsync(GetTickersRequest request, CancellationToken ct)
+        GetFuturesTickersOptions IFuturesTickerRestClient.GetFuturesTickersOptions { get; } = new GetFuturesTickersOptions(_exchangeName);
+        async Task<HttpResult<SharedFuturesTicker[]>> IFuturesTickerRestClient.GetFuturesTickersAsync(GetTickersRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTickerRestClient)this).GetFuturesTickersOptions.ValidateRequest(Exchange, request, request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.GetFuturesTickersOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesTicker[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesTicker[]>(Exchange, validationError);
 
             var type = !request.TradingMode.HasValue || request.TradingMode == TradingMode.PerpetualLinear || request.TradingMode == TradingMode.PerpetualInverse ? InstrumentType.Swap : InstrumentType.Futures;
             var resultTickers = ExchangeData.GetTickersAsync(type, ct: ct);
             var resultMarkPrice = ExchangeData.GetMarkPricesAsync(type, ct: ct);
             await Task.WhenAll(resultTickers, resultMarkPrice).ConfigureAwait(false);
-            if (!resultTickers.Result)
-                return resultTickers.Result.AsExchangeResult<SharedFuturesTicker[]>(Exchange, null, default);
-            if (!resultMarkPrice.Result)
-                return resultMarkPrice.Result.AsExchangeResult<SharedFuturesTicker[]>(Exchange, null, default);
+            if (!resultTickers.Result.Success)
+                return HttpResult.Fail<SharedFuturesTicker[]>(resultTickers.Result);
+            if (!resultMarkPrice.Result.Success)
+                return HttpResult.Fail<SharedFuturesTicker[]>(resultMarkPrice.Result);
 
-            return resultTickers.Result.AsExchangeResult<SharedFuturesTicker[]>(Exchange,
-                type == InstrumentType.Swap ? new[] { TradingMode.PerpetualLinear, TradingMode.PerpetualInverse } : new[] { TradingMode.DeliveryLinear, TradingMode.DeliveryInverse },
-                resultTickers.Result.Data.Select(x =>
+            return HttpResult.Ok(resultTickers.Result, resultTickers.Result.Data.Select(x =>
             {
                 var markPrice = resultMarkPrice.Result.Data.Single(p => p.Symbol == x.Symbol);
                 return new SharedFuturesTicker(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), x.Symbol, x.LastPrice, x.HighPrice, x.LowPrice, x.Volume, x.OpenPrice == null ? null : Math.Round((x.LastPrice ?? 0) / x.OpenPrice.Value * 100 - 100, 2))
@@ -1662,43 +1606,43 @@ namespace OKX.Net.Clients.UnifiedApi
         #region Position Mode client
 
         SharedPositionModeSelection IPositionModeRestClient.PositionModeSettingType => SharedPositionModeSelection.PerAccount;
-        GetPositionModeOptions IPositionModeRestClient.GetPositionModeOptions { get; } = new GetPositionModeOptions();
-        async Task<ExchangeWebResult<SharedPositionModeResult>> IPositionModeRestClient.GetPositionModeAsync(GetPositionModeRequest request, CancellationToken ct)
+        GetPositionModeOptions IPositionModeRestClient.GetPositionModeOptions { get; } = new GetPositionModeOptions(_exchangeName);
+        async Task<HttpResult<SharedPositionModeResult>> IPositionModeRestClient.GetPositionModeAsync(GetPositionModeRequest request, CancellationToken ct)
         {
-            var validationError = ((IPositionModeRestClient)this).GetPositionModeOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.GetPositionModeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedPositionModeResult>(Exchange, validationError);
+                return HttpResult.Fail<SharedPositionModeResult>(Exchange, validationError);
 
             var result = await Account.GetAccountConfigurationAsync(ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedPositionModeResult>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedPositionModeResult>(result);
 
-            return result.AsExchangeResult(Exchange, FuturesApiTypes, new SharedPositionModeResult(result.Data.PositionMode == PositionMode.LongShortMode ? SharedPositionMode.HedgeMode : SharedPositionMode.OneWay));
+            return HttpResult.Ok(result, new SharedPositionModeResult(result.Data.PositionMode == PositionMode.LongShortMode ? SharedPositionMode.HedgeMode : SharedPositionMode.OneWay));
         }
 
-        SetPositionModeOptions IPositionModeRestClient.SetPositionModeOptions { get; } = new SetPositionModeOptions();
-        async Task<ExchangeWebResult<SharedPositionModeResult>> IPositionModeRestClient.SetPositionModeAsync(SetPositionModeRequest request, CancellationToken ct)
+        SetPositionModeOptions IPositionModeRestClient.SetPositionModeOptions { get; } = new SetPositionModeOptions(_exchangeName);
+        async Task<HttpResult<SharedPositionModeResult>> IPositionModeRestClient.SetPositionModeAsync(SetPositionModeRequest request, CancellationToken ct)
         {
-            var validationError = ((IPositionModeRestClient)this).SetPositionModeOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.SetPositionModeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedPositionModeResult>(Exchange, validationError);
+                return HttpResult.Fail<SharedPositionModeResult>(Exchange, validationError);
 
             var result = await Account.SetPositionModeAsync(request.PositionMode == SharedPositionMode.HedgeMode ? PositionMode.LongShortMode : PositionMode.NetMode, ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedPositionModeResult>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedPositionModeResult>(result);
 
-            return result.AsExchangeResult(Exchange, FuturesApiTypes, new SharedPositionModeResult(request.PositionMode));
+            return HttpResult.Ok(result, new SharedPositionModeResult(request.PositionMode));
         }
         #endregion
 
         #region Position History client
 
-        GetPositionHistoryOptions IPositionHistoryRestClient.GetPositionHistoryOptions { get; } = new GetPositionHistoryOptions(false, true, true, 100);
-        async Task<ExchangeWebResult<SharedPositionHistory[]>> IPositionHistoryRestClient.GetPositionHistoryAsync(GetPositionHistoryRequest request, PageRequest? pageRequest, CancellationToken ct)
+        GetPositionHistoryOptions IPositionHistoryRestClient.GetPositionHistoryOptions { get; } = new GetPositionHistoryOptions(_exchangeName, false, true, true, 100);
+        async Task<HttpResult<SharedPositionHistory[]>> IPositionHistoryRestClient.GetPositionHistoryAsync(GetPositionHistoryRequest request, PageRequest? pageRequest, CancellationToken ct)
         {
-            var validationError = ((IPositionHistoryRestClient)this).GetPositionHistoryOptions.ValidateRequest(Exchange, request, request.Symbol?.TradingMode ?? request.TradingMode, FuturesApiTypes);
+            var validationError = SharedClient.GetPositionHistoryOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedPositionHistory[]>(Exchange, validationError);
+                return HttpResult.Fail<SharedPositionHistory[]>(Exchange, validationError);
 
             int limit = request.Limit ?? 100;
             var direction = DataDirection.Descending;
@@ -1712,8 +1656,8 @@ namespace OKX.Net.Clients.UnifiedApi
                 limit: pageParams.Limit,
                 ct: ct
                 ).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedPositionHistory[]>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedPositionHistory[]>(result);
 
             var nextPageRequest = Pagination.GetNextPageRequest(
                      () => Pagination.NextPageFromTime(pageParams, result.Data.Min(x => x.CreateTime)),
@@ -1723,10 +1667,7 @@ namespace OKX.Net.Clients.UnifiedApi
                      request.EndTime ?? DateTime.UtcNow,
                      pageParams);
 
-            return result.AsExchangeResult(
-                    Exchange,
-                    SupportedTradingModes.Where(x => x != TradingMode.Spot).ToArray(),
-                    ExchangeHelpers.ApplyFilter(result.Data, x => x.CreateTime, request.StartTime, request.EndTime, direction)
+            return HttpResult.Ok(result, ExchangeHelpers.ApplyFilter(result.Data, x => x.CreateTime, request.StartTime, request.EndTime, direction)
                     .Select(x => 
                         new SharedPositionHistory(
                             ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), 
@@ -1746,35 +1687,35 @@ namespace OKX.Net.Clients.UnifiedApi
         #endregion
 
         #region Fee Client
-        EndpointOptions<GetFeeRequest> IFeeRestClient.GetFeeOptions { get; } = new EndpointOptions<GetFeeRequest>(true);
+        GetFeeOptions IFeeRestClient.GetFeeOptions { get; } = new GetFeeOptions(_exchangeName, true);
 
-        async Task<ExchangeWebResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedFee>> IFeeRestClient.GetFeesAsync(GetFeeRequest request, CancellationToken ct)
         {
-            var validationError = ((IFeeRestClient)this).GetFeeOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFeeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFee>(Exchange, validationError);
+                return HttpResult.Fail<SharedFee>(Exchange, validationError);
 
             // Get data
             var type = request.Symbol!.TradingMode == TradingMode.Spot ? InstrumentType.Spot : request.Symbol.TradingMode == TradingMode.PerpetualLinear || request.Symbol.TradingMode == TradingMode.PerpetualInverse ? InstrumentType.Swap : InstrumentType.Futures;
             var result = await Account.GetFeeRatesAsync(type,
                 type == InstrumentType.Spot ? request.Symbol!.GetSymbol(FormatSymbol) : null,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedFee>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFee>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedFee(Math.Abs(result.Data.Maker ?? 0) * 100, Math.Abs(result.Data.Taker ?? 0) * 100));
+            return HttpResult.Ok(result, new SharedFee(Math.Abs(result.Data.Maker ?? 0) * 100, Math.Abs(result.Data.Taker ?? 0) * 100));
         }
         #endregion
 
         #region Spot Trigger Order Client
 
-        PlaceSpotTriggerOrderOptions ISpotTriggerOrderRestClient.PlaceSpotTriggerOrderOptions { get; } = new PlaceSpotTriggerOrderOptions(false);
-        async Task<ExchangeWebResult<SharedId>> ISpotTriggerOrderRestClient.PlaceSpotTriggerOrderAsync(PlaceSpotTriggerOrderRequest request, CancellationToken ct)
+        PlaceSpotTriggerOrderOptions ISpotTriggerOrderRestClient.PlaceSpotTriggerOrderOptions { get; } = new PlaceSpotTriggerOrderOptions(_exchangeName, false);
+        async Task<HttpResult<SharedId>> ISpotTriggerOrderRestClient.PlaceSpotTriggerOrderAsync(PlaceSpotTriggerOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTriggerOrderRestClient)this).PlaceSpotTriggerOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes, ((ISpotOrderRestClient)this).SpotSupportedOrderQuantity);
+            var validationError = SharedClient.PlaceSpotTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await Trading.PlaceAlgoOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -1787,36 +1728,36 @@ namespace OKX.Net.Clients.UnifiedApi
                 orderPrice: request.OrderPrice ?? -1,
                 clientOrderId: request.ClientOrderId,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(result.Data.AlgoOrderId!));
+            return HttpResult.Ok(result, new SharedId(result.Data.AlgoOrderId!));
         }
 
 
-        EndpointOptions<GetOrderRequest> ISpotTriggerOrderRestClient.GetSpotTriggerOrderOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedSpotTriggerOrder>> ISpotTriggerOrderRestClient.GetSpotTriggerOrderAsync(GetOrderRequest request, CancellationToken ct)
+        GetSpotTriggerOrderOptions ISpotTriggerOrderRestClient.GetSpotTriggerOrderOptions { get; } = new GetSpotTriggerOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedSpotTriggerOrder>> ISpotTriggerOrderRestClient.GetSpotTriggerOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTriggerOrderRestClient)this).GetSpotTriggerOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotTriggerOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotTriggerOrder>(Exchange, validationError);
 
             var order = await Trading.GetAlgoOrderAsync(request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedSpotTriggerOrder>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedSpotTriggerOrder>(order);
 
             OKXOrder? orderDetails = null;
             if (order.Data.OrderIdList?.Any() == true)
             {
                 var orderDetailsRequest = await Trading.GetOrderDetailsAsync(request.Symbol!.GetSymbol(FormatSymbol), order.Data.OrderIdList.First(), ct: ct).ConfigureAwait(false);
-                if (!orderDetailsRequest)
-                    return orderDetailsRequest.AsExchangeResult<SharedSpotTriggerOrder>(Exchange, null, default);
+                if (!orderDetailsRequest.Success)
+                    return HttpResult.Fail<SharedSpotTriggerOrder>(orderDetailsRequest);
 
                 orderDetails = orderDetailsRequest.Data;
             }
 
-            return order.AsExchangeResult(Exchange, TradingMode.Spot, new SharedSpotTriggerOrder(
+            return HttpResult.Ok(order, new SharedSpotTriggerOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicSpotId, order.Data.Symbol),
                 order.Data.Symbol!,
                 order.Data.AlgoId!,
@@ -1856,26 +1797,26 @@ namespace OKX.Net.Clients.UnifiedApi
             return SharedTriggerOrderStatus.Unknown;
         }
 
-        EndpointOptions<CancelOrderRequest> ISpotTriggerOrderRestClient.CancelSpotTriggerOrderOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> ISpotTriggerOrderRestClient.CancelSpotTriggerOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelSpotTriggerOrderOptions ISpotTriggerOrderRestClient.CancelSpotTriggerOrderOptions { get; } = new CancelSpotTriggerOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> ISpotTriggerOrderRestClient.CancelSpotTriggerOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotTriggerOrderRestClient)this).CancelSpotTriggerOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelSpotTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var order = await Trading.CancelAlgoOrderAsync(
                 [new OKXAlgoOrderRequest { Symbol = request.Symbol!.GetSymbol(FormatSymbol), AlgoOrderId = request.OrderId }],
                 ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(request.OrderId));
+            return HttpResult.Ok(order, new SharedId(request.OrderId));
         }
 
         #endregion
 
         #region Futures Trigger Order Client
-        PlaceFuturesTriggerOrderOptions IFuturesTriggerOrderRestClient.PlaceFuturesTriggerOrderOptions { get; } = new PlaceFuturesTriggerOrderOptions(false)
+        PlaceFuturesTriggerOrderOptions IFuturesTriggerOrderRestClient.PlaceFuturesTriggerOrderOptions { get; } = new PlaceFuturesTriggerOrderOptions(_exchangeName, false)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
@@ -1883,12 +1824,12 @@ namespace OKX.Net.Clients.UnifiedApi
                 new ParameterDescription(nameof(PlaceFuturesTriggerOrderRequest.PositionMode), typeof(SharedPositionMode), "Position mode the account is in", SharedPositionMode.HedgeMode)
             }
         };
-        async Task<ExchangeWebResult<SharedId>> IFuturesTriggerOrderRestClient.PlaceFuturesTriggerOrderAsync(PlaceFuturesTriggerOrderRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IFuturesTriggerOrderRestClient.PlaceFuturesTriggerOrderAsync(PlaceFuturesTriggerOrderRequest request, CancellationToken ct)
         {
             var side = GetTriggerOrderSide(request);
-            var validationError = ((IFuturesTriggerOrderRestClient)this).PlaceFuturesTriggerOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes, side == OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell, ((IFuturesOrderRestClient)this).FuturesSupportedOrderQuantity);
+            var validationError = SharedClient.PlaceFuturesTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await Trading.PlaceAlgoOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -1901,11 +1842,11 @@ namespace OKX.Net.Clients.UnifiedApi
                 clientOrderId: request.ClientOrderId,
                 positionSide: request.PositionMode == SharedPositionMode.OneWay ? PositionSide.Net : request.PositionSide == SharedPositionSide.Long ? PositionSide.Long : PositionSide.Short,
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(result.Data.AlgoOrderId!));
+            return HttpResult.Ok(result, new SharedId(result.Data.AlgoOrderId!));
         }
 
         private OrderSide GetTriggerOrderSide(PlaceFuturesTriggerOrderRequest request)
@@ -1916,28 +1857,28 @@ namespace OKX.Net.Clients.UnifiedApi
             return request.OrderDirection == SharedTriggerOrderDirection.Enter ? OrderSide.Sell : OrderSide.Buy;
         }
 
-        EndpointOptions<GetOrderRequest> IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedFuturesTriggerOrder>> IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderAsync(GetOrderRequest request, CancellationToken ct)
+        GetFuturesTriggerOrderOptions IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderOptions { get; } = new GetFuturesTriggerOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedFuturesTriggerOrder>> IFuturesTriggerOrderRestClient.GetFuturesTriggerOrderAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTriggerOrderRestClient)this).GetFuturesTriggerOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesTriggerOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesTriggerOrder>(Exchange, validationError);
 
             var order = await Trading.GetAlgoOrderAsync(request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedFuturesTriggerOrder>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedFuturesTriggerOrder>(order);
 
             OKXOrder? orderDetails = null;
             if (order.Data.OrderIdList?.Any() == true)
             {
                 var orderDetailsRequest = await Trading.GetOrderDetailsAsync(request.Symbol!.GetSymbol(FormatSymbol), order.Data.OrderIdList.First(), ct: ct).ConfigureAwait(false);
-                if (!orderDetailsRequest)
-                    return orderDetailsRequest.AsExchangeResult<SharedFuturesTriggerOrder>(Exchange, null, default);
+                if (!orderDetailsRequest.Success)
+                    return HttpResult.Fail<SharedFuturesTriggerOrder>(orderDetailsRequest);
 
                 orderDetails = orderDetailsRequest.Data;
             }
 
-            return order.AsExchangeResult(Exchange, request.TradingMode, new SharedFuturesTriggerOrder(
+            return HttpResult.Ok(order, new SharedFuturesTriggerOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicFuturesId, order.Data.Symbol),
                 order.Data.Symbol!,
                 order.Data.AlgoId!,
@@ -1962,26 +1903,26 @@ namespace OKX.Net.Clients.UnifiedApi
             });
         }
 
-        EndpointOptions<CancelOrderRequest> IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelFuturesTriggerOrderOptions IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderOptions { get; } = new CancelFuturesTriggerOrderOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> IFuturesTriggerOrderRestClient.CancelFuturesTriggerOrderAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTriggerOrderRestClient)this).CancelFuturesTriggerOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelFuturesTriggerOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var order = await Trading.CancelAlgoOrderAsync(
                 [new OKXAlgoOrderRequest { Symbol = request.Symbol!.GetSymbol(FormatSymbol), AlgoOrderId = request.OrderId }],
                 ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(request.OrderId));
+            return HttpResult.Ok(order, new SharedId(request.OrderId));
         }
 
         #endregion
 
         #region Tp/SL Client
-        EndpointOptions<SetTpSlRequest> IFuturesTpSlRestClient.SetFuturesTpSlOptions { get; } = new EndpointOptions<SetTpSlRequest>(true)
+        SetFuturesTpSlOptions IFuturesTpSlRestClient.SetFuturesTpSlOptions { get; } = new SetFuturesTpSlOptions(_exchangeName, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
@@ -1990,11 +1931,11 @@ namespace OKX.Net.Clients.UnifiedApi
             }
         };
 
-        async Task<ExchangeWebResult<SharedId>> IFuturesTpSlRestClient.SetFuturesTpSlAsync(SetTpSlRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> IFuturesTpSlRestClient.SetFuturesTpSlAsync(SetTpSlRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTpSlRestClient)this).SetFuturesTpSlOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SetFuturesTpSlOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var result = await Trading.PlaceAlgoOrderAsync(
                 request.Symbol!.GetSymbol(FormatSymbol),
@@ -2010,14 +1951,14 @@ namespace OKX.Net.Clients.UnifiedApi
                 positionSide: request.PositionMode == SharedPositionMode.OneWay ? null : request.PositionSide == SharedPositionSide.Long ? PositionSide.Long : PositionSide.Short,
                 ct: ct).ConfigureAwait(false);
 
-            if (!result)
-                return result.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<SharedId>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(result.Data.AlgoOrderId!));
+            return HttpResult.Ok(result, new SharedId(result.Data.AlgoOrderId!));
         }
 
-        EndpointOptions<CancelTpSlRequest> IFuturesTpSlRestClient.CancelFuturesTpSlOptions { get; } = new EndpointOptions<CancelTpSlRequest>(true)
+        CancelFuturesTpSlOptions IFuturesTpSlRestClient.CancelFuturesTpSlOptions { get; } = new CancelFuturesTpSlOptions(_exchangeName, true)
         {
             RequiredOptionalParameters = new List<ParameterDescription>
             {
@@ -2025,11 +1966,11 @@ namespace OKX.Net.Clients.UnifiedApi
             }
         };
 
-        async Task<ExchangeWebResult<bool>> IFuturesTpSlRestClient.CancelFuturesTpSlAsync(CancelTpSlRequest request, CancellationToken ct)
+        async Task<HttpResult<bool>> IFuturesTpSlRestClient.CancelFuturesTpSlAsync(CancelTpSlRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesTpSlRestClient)this).CancelFuturesTpSlOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelFuturesTpSlOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<bool>(Exchange, validationError);
+                return HttpResult.Fail<bool>(Exchange, validationError);
 
             var result = await Trading.CancelAlgoOrderAsync(
                 [new OKXAlgoOrderRequest {
@@ -2037,29 +1978,29 @@ namespace OKX.Net.Clients.UnifiedApi
                     AlgoOrderId = request.OrderId!
                 }],
                 ct: ct).ConfigureAwait(false);
-            if (!result)
-                return result.AsExchangeResult<bool>(Exchange, null, default);
+            if (!result.Success)
+                return HttpResult.Fail<bool>(result);
 
             // Return
-            return result.AsExchangeResult(Exchange, request.Symbol.TradingMode, true);
+            return HttpResult.Ok(result, true);
         }
 
         #endregion
 
         #region Futures Client Id Order Client
 
-        EndpointOptions<GetOrderRequest> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedFuturesOrder>> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
+        GetFuturesOrderByClientOrderIdOptions IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdOptions { get; } = new GetFuturesOrderByClientOrderIdOptions(_exchangeName, true);
+        async Task<HttpResult<SharedFuturesOrder>> IFuturesOrderClientIdRestClient.GetFuturesOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).GetFuturesOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedFuturesOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedFuturesOrder>(Exchange, validationError);
 
             var order = await Trading.GetOrderDetailsAsync(request.Symbol!.GetSymbol(FormatSymbol), clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedFuturesOrder>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedFuturesOrder>(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedFuturesOrder(
+            return HttpResult.Ok(order, new SharedFuturesOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicFuturesId, order.Data.Symbol),
                 order.Data.Symbol,
                 order.Data.OrderId.ToString()!,
@@ -2085,35 +2026,35 @@ namespace OKX.Net.Clients.UnifiedApi
             });
         }
 
-        EndpointOptions<CancelOrderRequest> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelFuturesOrderByClientOrderIdOptions IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdOptions { get; } = new CancelFuturesOrderByClientOrderIdOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> IFuturesOrderClientIdRestClient.CancelFuturesOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderRestClient)this).CancelFuturesOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var order = await Trading.CancelOrderAsync(request.Symbol!.GetSymbol(FormatSymbol), clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(order.Data.OrderId.ToString()!));
+            return HttpResult.Ok(order, new SharedId(order.Data.OrderId.ToString()!));
         }
         #endregion
 
         #region Spot Client Id Order Client
 
-        EndpointOptions<GetOrderRequest> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdOptions { get; } = new EndpointOptions<GetOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedSpotOrder>> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
+        GetSpotOrderByClientOrderIdOptions ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdOptions { get; } = new GetSpotOrderByClientOrderIdOptions(_exchangeName, true);
+        async Task<HttpResult<SharedSpotOrder>> ISpotOrderClientIdRestClient.GetSpotOrderByClientOrderIdAsync(GetOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).GetSpotOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.GetSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedSpotOrder>(Exchange, validationError);
+                return HttpResult.Fail<SharedSpotOrder>(Exchange, validationError);
 
             var order = await Trading.GetOrderDetailsAsync(request.Symbol!.GetSymbol(FormatSymbol), clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedSpotOrder>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedSpotOrder>(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedSpotOrder(
+            return HttpResult.Ok(order, new SharedSpotOrder(
                 ExchangeSymbolCache.ParseSymbol(_topicSpotId, order.Data.Symbol),
                 order.Data.Symbol,
                 order.Data.OrderId.ToString()!,
@@ -2134,37 +2075,37 @@ namespace OKX.Net.Clients.UnifiedApi
             });
         }
 
-        EndpointOptions<CancelOrderRequest> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdOptions { get; } = new EndpointOptions<CancelOrderRequest>(true);
-        async Task<ExchangeWebResult<SharedId>> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
+        CancelSpotOrderByClientOrderIdOptions ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdOptions { get; } = new CancelSpotOrderByClientOrderIdOptions(_exchangeName, true);
+        async Task<HttpResult<SharedId>> ISpotOrderClientIdRestClient.CancelSpotOrderByClientOrderIdAsync(CancelOrderRequest request, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderRestClient)this).CancelSpotOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.CancelSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var order = await Trading.CancelOrderAsync(request.Symbol!.GetSymbol(FormatSymbol), clientOrderId: request.OrderId, ct: ct).ConfigureAwait(false);
-            if (!order)
-                return order.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!order.Success)
+                return HttpResult.Fail<SharedId>(order);
 
-            return order.AsExchangeResult(Exchange, request.Symbol.TradingMode, new SharedId(order.Data.OrderId.ToString()!));
+            return HttpResult.Ok(order, new SharedId(order.Data.OrderId.ToString()!));
         }
         #endregion
 
         #region Transfer client
 
-        TransferOptions ITransferRestClient.TransferOptions { get; } = new TransferOptions([
+        TransferOptions ITransferRestClient.TransferOptions { get; } = new TransferOptions(_exchangeName, [
             SharedAccountType.Funding,
             SharedAccountType.Unified
             ]);
-        async Task<ExchangeWebResult<SharedId>> ITransferRestClient.TransferAsync(TransferRequest request, CancellationToken ct)
+        async Task<HttpResult<SharedId>> ITransferRestClient.TransferAsync(TransferRequest request, CancellationToken ct)
         {
-            var validationError = ((ITransferRestClient)this).TransferOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.TransferOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeWebResult<SharedId>(Exchange, validationError);
+                return HttpResult.Fail<SharedId>(Exchange, validationError);
 
             var fromType = GetTransferType(request.FromAccountType);
             var toType = GetTransferType(request.ToAccountType);
             if (fromType == null || toType == null)
-                return new ExchangeWebResult<SharedId>(Exchange, ArgumentError.Invalid("To/From AccountType", "invalid to/from account combination"));
+                return HttpResult.Fail<SharedId>(Exchange, ArgumentError.Invalid("To/From AccountType", "invalid to/from account combination"));
 
             // Get data
             var transfer = await Account.TransferAsync(
@@ -2174,10 +2115,10 @@ namespace OKX.Net.Clients.UnifiedApi
                 fromType.Value,
                 toType.Value,
                 ct: ct).ConfigureAwait(false);
-            if (!transfer)
-                return transfer.AsExchangeResult<SharedId>(Exchange, null, default);
+            if (!transfer.Success)
+                return HttpResult.Fail<SharedId>(transfer);
 
-            return transfer.AsExchangeResult(Exchange, TradingMode.Spot, new SharedId(transfer.Data.TransferId?.ToString() ?? ""));
+            return HttpResult.Ok(transfer, new SharedId(transfer.Data.TransferId?.ToString() ?? ""));
         }
 
         private AccountType? GetTransferType(SharedAccountType type)

--- a/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiSubAccounts.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiSubAccounts.cs
@@ -16,7 +16,7 @@ internal class OKXRestClientUnifiedApiSubAccounts : IOKXRestClientUnifiedApiSubA
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXSubAccount[]>> GetSubAccountsAsync(
+    public virtual async Task<HttpResult<OKXSubAccount[]>> GetSubAccountsAsync(
         bool? enable = null,
         string? subAccountName = null,
         DateTime? endTime = null,
@@ -27,20 +27,20 @@ internal class OKXRestClientUnifiedApiSubAccounts : IOKXRestClientUnifiedApiSubA
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("enable", enable);
-        parameters.AddOptionalParameter("subAcct", subAccountName);
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
-        parameters.AddOptionalParameter("limit", limit.ToString(CultureInfo.InvariantCulture));
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("enable", enable);
+        parameters.Add("subAcct", subAccountName);
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
+        parameters.Add("limit", limit.ToString(CultureInfo.InvariantCulture));
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/users/subaccount/list", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/users/subaccount/list", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(2, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXSubAccount[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXSubAccountApiKey>> ResetSubAccountApiKeyAsync(
+    public virtual async Task<HttpResult<OKXSubAccountApiKey>> ResetSubAccountApiKeyAsync(
         string subAccountName,
         string apiKey,
         string? apiLabel = null,
@@ -49,60 +49,60 @@ internal class OKXRestClientUnifiedApiSubAccounts : IOKXRestClientUnifiedApiSubA
         string? ipAddresses = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "subAcct", subAccountName },
             { "apiKey", apiKey}
         };
-        parameters.AddOptionalParameter("label", apiLabel);
-        parameters.AddOptionalParameter("ip", ipAddresses);
+        parameters.Add("label", apiLabel);
+        parameters.Add("ip", ipAddresses);
 
         var permissions = new List<string>();
         if (readPermission.HasValue && readPermission.Value) permissions.Add("read_only");
         if (tradePermission.HasValue && tradePermission.Value) permissions.Add("trade");
         if (permissions.Count > 0)
-            parameters.AddOptionalParameter("perm", string.Join(",", permissions));
+            parameters.Add("perm", string.Join(",", permissions));
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/users/subaccount/modify-apikey", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/users/subaccount/modify-apikey", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(1, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXSubAccountApiKey>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAccountBalance>> GetSubAccountTradingBalancesAsync(
+    public virtual async Task<HttpResult<OKXAccountBalance>> GetSubAccountTradingBalancesAsync(
         string subAccountName,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             {"subAcct", subAccountName },
         };
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/subaccount/balances", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/subaccount/balances", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(6, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXAccountBalance>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXSubAccountFundingBalance[]>> GetSubAccountFundingBalancesAsync(
+    public virtual async Task<HttpResult<OKXSubAccountFundingBalance[]>> GetSubAccountFundingBalancesAsync(
         string subAccountName,
         string? asset = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             {"subAcct", subAccountName },
         };
 
-        parameters.AddOptionalParameter("ccy", asset);
+        parameters.Add("ccy", asset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/asset/subaccount/balances", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/asset/subaccount/balances", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(6, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXSubAccountFundingBalance[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXSubAccountBill[]>> GetSubAccountBillsAsync(
+    public virtual async Task<HttpResult<OKXSubAccountBill[]>> GetSubAccountBillsAsync(
         string? subAccountName = null,
         string? asset = null,
         SubAccountTransferType? type = null,
@@ -114,21 +114,21 @@ internal class OKXRestClientUnifiedApiSubAccounts : IOKXRestClientUnifiedApiSubA
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("subAcct", subAccountName);
-        parameters.AddOptionalParameter("ccy", asset);
-        parameters.AddOptionalEnum("type", type);
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
-        parameters.AddOptionalParameter("limit", limit.ToString(CultureInfo.InvariantCulture));
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("subAcct", subAccountName);
+        parameters.Add("ccy", asset);
+        parameters.Add("type", type);
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
+        parameters.Add("limit", limit.ToString(CultureInfo.InvariantCulture));
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/asset/subaccount/bills", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/asset/subaccount/bills", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(6, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXSubAccountBill[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXSubAccountTransfer>> TransferBetweenSubAccountsAsync(
+    public virtual async Task<HttpResult<OKXSubAccountTransfer>> TransferBetweenSubAccountsAsync(
         string asset,
         decimal amount,
         AccountType fromAccount,
@@ -137,40 +137,40 @@ internal class OKXRestClientUnifiedApiSubAccounts : IOKXRestClientUnifiedApiSubA
         string toSubAccountName,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             {"ccy", asset },
             {"amt", amount.ToString(CultureInfo.InvariantCulture) },
             {"fromSubAccount", fromSubAccountName },
             {"toSubAccount", toSubAccountName },
         };
-        parameters.AddEnum("from", fromAccount);
-        parameters.AddEnum("to", toAccount);
+        parameters.Add("from", fromAccount);
+        parameters.Add("to", toAccount);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/asset/subaccount/transfer", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/asset/subaccount/transfer", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(1, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXSubAccountTransfer>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXSubAccountMaxWithdrawal[]>> GetSubAccountMaxWithdrawalsAsync(
+    public virtual async Task<HttpResult<OKXSubAccountMaxWithdrawal[]>> GetSubAccountMaxWithdrawalsAsync(
         string subAccountName,
         string? asset = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             {"subAcct", subAccountName },
         };
-        parameters.AddOptionalParameter("ccy", asset);
+        parameters.Add("ccy", asset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/account/subaccount/max-withdrawal", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/account/subaccount/max-withdrawal", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXSubAccountMaxWithdrawal[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXSubAccountBill[]>> GetManagedSubAccountBillsAsync(
+    public virtual async Task<HttpResult<OKXSubAccountBill[]>> GetManagedSubAccountBillsAsync(
         string? subAccountName = null,
         string? asset = null,
         SubAccountTransferType? type = null,
@@ -182,51 +182,51 @@ internal class OKXRestClientUnifiedApiSubAccounts : IOKXRestClientUnifiedApiSubA
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("subAcct", subAccountName);
-        parameters.AddOptionalParameter("ccy", asset);
-        parameters.AddOptionalEnum("type", type);
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
-        parameters.AddOptionalParameter("limit", limit.ToString(CultureInfo.InvariantCulture));
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("subAcct", subAccountName);
+        parameters.Add("ccy", asset);
+        parameters.Add("type", type);
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString());
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString());
+        parameters.Add("limit", limit.ToString(CultureInfo.InvariantCulture));
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/asset/subaccount/managed-subaccount-bills", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/asset/subaccount/managed-subaccount-bills", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(6, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXSubAccountBill[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXEntrustSubAccount[]>> GetEntrustSubAccountsAsync(
+    public virtual async Task<HttpResult<OKXEntrustSubAccount[]>> GetEntrustSubAccountsAsync(
         string? subAccountName = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("subAcct", subAccountName);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("subAcct", subAccountName);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/users/entrust-subaccount-list", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/users/entrust-subaccount-list", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(1, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXEntrustSubAccount[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXSubAccountApiKey[]>> GetSubAccountApiKeysAsync(
+    public virtual async Task<HttpResult<OKXSubAccountApiKey[]>> GetSubAccountApiKeysAsync(
         string subAccountName,
         string? apiKey = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             {"subAcct", subAccountName },
         };
-        parameters.AddOptionalParameter("apiKey", apiKey);
+        parameters.Add("apiKey", apiKey);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/users/subaccount/apikey", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/users/subaccount/apikey", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXSubAccountApiKey[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXSubAccountApiKey>> CreateSubAccountApiKeyAsync(
+    public virtual async Task<HttpResult<OKXSubAccountApiKey>> CreateSubAccountApiKeyAsync(
         string subAccountName,
         string apiLabel,
         string passphrase,
@@ -235,7 +235,7 @@ internal class OKXRestClientUnifiedApiSubAccounts : IOKXRestClientUnifiedApiSubA
         string? ipAddresses = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             {"subAcct", subAccountName },
             {"label", apiLabel },
@@ -248,60 +248,60 @@ internal class OKXRestClientUnifiedApiSubAccounts : IOKXRestClientUnifiedApiSubA
         if (permissions.Count > 0)
             parameters.AddParameter("perm", string.Join(",", permissions));
 
-        parameters.AddOptionalParameter("ip", ipAddresses);
+        parameters.Add("ip", ipAddresses);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/users/subaccount/apikey", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/users/subaccount/apikey", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXSubAccountApiKey>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXSubAccountApiKey>> DeleteSubAccountApiKeyAsync(
+    public virtual async Task<HttpResult<OKXSubAccountApiKey>> DeleteSubAccountApiKeyAsync(
         string subAccountName,
         string apiKey,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             {"subAcct", subAccountName },
             {"apiKey", apiKey },
         };
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/users/subaccount/delete-apikey", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/users/subaccount/delete-apikey", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXSubAccountApiKey>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXSubAccount>> SetSubAccountTransferOutAsync(
+    public virtual async Task<HttpResult<OKXSubAccount>> SetSubAccountTransferOutAsync(
         string subAccountName,
         bool canTransferOut,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             {"subAcct", subAccountName },
             {"canTransOut", canTransferOut },
         };
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/users/subaccount/set-transfer-out", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/users/subaccount/set-transfer-out", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXSubAccount>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXSubAccount>> CreateSubAccountAsync(
+    public virtual async Task<HttpResult<OKXSubAccount>> CreateSubAccountAsync(
         string subAccountName,
         string? label = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             {"subAcct", subAccountName },
         };
-        parameters.AddOptionalParameter("label", label);
+        parameters.Add("label", label);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/users/subaccount/create-subaccount", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/users/subaccount/create-subaccount", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXSubAccount>(request, parameters, ct).ConfigureAwait(false);
     }

--- a/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiTrading.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXRestClientUnifiedApiTrading.cs
@@ -17,7 +17,7 @@ internal class OKXRestClientUnifiedApiTrading : IOKXRestClientUnifiedApiTrading
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXOrderPlaceResponse>> PlaceOrderAsync(
+    public virtual async Task<HttpResult<OKXOrderPlaceResponse>> PlaceOrderAsync(
         string symbol,
         OrderSide side,
         OrderType type,
@@ -47,62 +47,62 @@ internal class OKXRestClientUnifiedApiTrading : IOKXRestClientUnifiedApiTrading
 
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             {"instId", symbol },
             {"sz", quantity.ToString(CultureInfo.InvariantCulture) },
             {"tag", !string.IsNullOrEmpty(tag) ? tag! : LibraryHelpers.GetClientReference(() => _baseClient.ClientOptions.BrokerId, _baseClient.Exchange) }
         };
 
-        parameters.AddOptional("clOrdId", clientOrderId);
-        parameters.AddEnum("tdMode", tradeMode ?? TradeMode.Cash);
-        parameters.AddEnum("side", side);
-        parameters.AddEnum("ordType", type);
-        parameters.AddOptionalString("px", price);
-        parameters.AddOptional("ccy", asset);
+        parameters.Add("clOrdId", clientOrderId);
+        parameters.Add("tdMode", tradeMode ?? TradeMode.Cash);
+        parameters.Add("side", side);
+        parameters.Add("ordType", type);
+        parameters.Add("px", price);
+        parameters.Add("ccy", asset);
 
-        parameters.AddOptionalEnum("tgtCcy", quantityAsset);
-        parameters.AddOptionalEnum("quickMgnType", quickMarginType);
-        parameters.AddOptional("stpId", selfTradePreventionId);
-        parameters.AddOptionalEnum("stpMode", selfTradePreventionMode);
-        parameters.AddOptional("tradeQuoteCcy", tradeQuoteAsset);
-        parameters.AddOptional("pxAmendType", priceAmendType);
-        parameters.AddOptional("isElpTakerAccess", isElpTakerAccess);
-        parameters.AddOptional("slippagePct", maxSlippagePercentage);
+        parameters.Add("tgtCcy", quantityAsset);
+        parameters.Add("quickMgnType", quickMarginType);
+        parameters.Add("stpId", selfTradePreventionId);
+        parameters.Add("stpMode", selfTradePreventionMode);
+        parameters.Add("tradeQuoteCcy", tradeQuoteAsset);
+        parameters.Add("pxAmendType", priceAmendType);
+        parameters.Add("isElpTakerAccess", isElpTakerAccess);
+        parameters.Add("slippagePct", maxSlippagePercentage);
 
         if (attachedAlgoOrders != null)
         {
             foreach (var attachOrder in attachedAlgoOrders)
                 attachOrder.ClientOrderId = LibraryHelpers.GetClientReference(() => _baseClient.ClientOptions.BrokerId, _baseClient.Exchange);
         }
-        parameters.AddOptional("attachAlgoOrds", attachedAlgoOrders?.ToArray());
+        parameters.AddArray("attachAlgoOrds", attachedAlgoOrders?.ToArray());
 
-        parameters.AddOptional("reduceOnly", reduceOnly);
-        parameters.AddOptionalEnum("posSide", positionSide);
+        parameters.Add("reduceOnly", reduceOnly);
+        parameters.Add("posSide", positionSide);
 
-        parameters.AddOptionalString("pxUsd", priceUsd);
-        parameters.AddOptionalString("pxVol", priceVol);
-        parameters.AddOptional("banAmend", banAmend);
+        parameters.Add("pxUsd", priceUsd);
+        parameters.Add("pxVol", priceVol);
+        parameters.Add("banAmend", banAmend);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/trade/order", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/trade/order", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(60, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         var result = await _baseClient.SendRawAsync<OKXRestApiResponse<OKXOrderPlaceResponse[]>>(request, parameters, ct, rateLimitKeySuffix: symbol).ConfigureAwait(false);
-        if (!result)
-            return result.As<OKXOrderPlaceResponse>(default);
+        if (!result.Success)
+            return HttpResult.Fail<OKXOrderPlaceResponse>(result);
 
         var detailed = result.Data.Data?.FirstOrDefault();
         if (result.Data.ErrorCode > 0)
         {
             if (detailed != null)
-                return result.AsError<OKXOrderPlaceResponse>(new ServerError(detailed.Code, _baseClient.GetErrorInfo(detailed.Code, detailed.Message)));
+                return HttpResult.Fail<OKXOrderPlaceResponse>(result, new ServerError(detailed.Code, _baseClient.GetErrorInfo(detailed.Code, detailed.Message)));
 
-            return result.AsError<OKXOrderPlaceResponse>(new ServerError(result.Data.ErrorCode, _baseClient.GetErrorInfo(result.Data.ErrorCode, result.Data.ErrorMessage!)));
+            return HttpResult.Fail<OKXOrderPlaceResponse>(result, new ServerError(result.Data.ErrorCode, _baseClient.GetErrorInfo(result.Data.ErrorCode, result.Data.ErrorMessage!)));
         }
 
-        return result.As(detailed!);
+        return HttpResult.Ok(result, detailed!);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXCheckOrderResponse>> CheckOrderAsync(
+    public virtual async Task<HttpResult<OKXCheckOrderResponse>> CheckOrderAsync(
         string symbol,
         OrderSide side,
         OrderType type,
@@ -122,127 +122,128 @@ internal class OKXRestClientUnifiedApiTrading : IOKXRestClientUnifiedApiTrading
         bool? reduceOnly = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             {"instId", symbol },
             {"sz", quantity.ToString(CultureInfo.InvariantCulture) }
         };
-        parameters.AddEnum("tdMode", tradeMode ?? TradeMode.Cash);
-        parameters.AddEnum("side", side);
-        parameters.AddEnum("ordType", type);
-        parameters.AddOptionalParameter("px", price?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("tdMode", tradeMode ?? TradeMode.Cash);
+        parameters.Add("side", side);
+        parameters.Add("ordType", type);
+        parameters.Add("px", price?.ToString(CultureInfo.InvariantCulture));
 
-        parameters.AddOptionalParameter("tgtCcy", EnumConverter.GetString(quantityAsset));
-        parameters.AddOptionalParameter("tpTriggerPx", takeProfitTriggerPrice);
-        parameters.AddOptionalParameter("slTriggerPx", stopLossTriggerPrice);
-        parameters.AddOptionalParameter("tpOrdPx", takeProfitOrderPrice);
-        parameters.AddOptionalParameter("slOrdPx", stopLossOrderPrice);
-        parameters.AddOptionalParameter("tpTriggerPxType", EnumConverter.GetString(takeProfitTriggerPriceType));
-        parameters.AddOptionalParameter("slTriggerPxType", EnumConverter.GetString(stopLossTriggerPriceType));
+        parameters.Add("tgtCcy", EnumConverter.GetString(quantityAsset));
+        parameters.Add("tpTriggerPx", takeProfitTriggerPrice);
+        parameters.Add("slTriggerPx", stopLossTriggerPrice);
+        parameters.Add("tpOrdPx", takeProfitOrderPrice);
+        parameters.Add("slOrdPx", stopLossOrderPrice);
+        parameters.Add("tpTriggerPxType", EnumConverter.GetString(takeProfitTriggerPriceType));
+        parameters.Add("slTriggerPxType", EnumConverter.GetString(stopLossTriggerPriceType));
 
-        parameters.AddOptionalParameter("reduceOnly", reduceOnly);
-        parameters.AddOptionalEnum("posSide", positionSide);
+        parameters.Add("reduceOnly", reduceOnly);
+        parameters.Add("posSide", positionSide);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/trade/order-precheck", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/trade/order-precheck", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(5, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         var result = await _baseClient.SendRawAsync<OKXRestApiResponse<OKXCheckOrderResponse[]>>(request, parameters, ct).ConfigureAwait(false);
-        return result.As<OKXCheckOrderResponse>(result.Data?.Data?.FirstOrDefault());
+        if (!result.Success)
+            return HttpResult.Fail<OKXCheckOrderResponse>(result);
+
+        return HttpResult.Ok(result, result.Data.Data!.First());
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<CallResult<OKXOrderPlaceResponse>[]>> PlaceMultipleOrdersAsync(IEnumerable<OKXOrderPlaceRequest> orders, CancellationToken ct = default)
+    public virtual async Task<HttpResult<CallResult<OKXOrderPlaceResponse>[]>> PlaceMultipleOrdersAsync(IEnumerable<OKXOrderPlaceRequest> orders, CancellationToken ct = default)
     {
         foreach (var order in orders)
             order.Tag = LibraryHelpers.GetClientReference(() => _baseClient.ClientOptions.BrokerId, _baseClient.Exchange);
 
-        var parameters = new ParameterCollection();
-        parameters.SetBody(orders.ToArray());
+        var parameters = new Parameters(orders.ToArray(), OKXExchange._parameterSerializationSettings);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/trade/batch-orders", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/trade/batch-orders", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(300, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         var result = await _baseClient.SendRawAsync<OKXRestApiResponse<OKXOrderPlaceResponse[]>>(request, parameters, ct).ConfigureAwait(false);
-        if (!result)
-            return result.As<CallResult<OKXOrderPlaceResponse>[]>(default);
+        if (!result.Success)
+            return HttpResult.Fail<CallResult<OKXOrderPlaceResponse>[]>(result);
 
         if (result.Data.ErrorCode > 0 && result.Data.Data?.Any() != true)
-            return result.AsError<CallResult<OKXOrderPlaceResponse>[]>(new ServerError(result.Data.ErrorCode, _baseClient.GetErrorInfo(result.Data.ErrorCode, result.Data.ErrorMessage!)));
+            return HttpResult.Fail<CallResult<OKXOrderPlaceResponse>[]>(result, new ServerError(result.Data.ErrorCode, _baseClient.GetErrorInfo(result.Data.ErrorCode, result.Data.ErrorMessage!)));
 
         var ordersResult = new List<CallResult<OKXOrderPlaceResponse>>();
         foreach (var item in result.Data.Data!)
         {
             if (item.Code > 0)
-                ordersResult.Add(new CallResult<OKXOrderPlaceResponse>(item, null, new ServerError(item.Code, _baseClient.GetErrorInfo(item.Code, item.Message!))));
+                ordersResult.Add(CallResult.Fail<OKXOrderPlaceResponse>(new ServerError(item.Code, _baseClient.GetErrorInfo(item.Code, item.Message!))));
             else
-                ordersResult.Add(new CallResult<OKXOrderPlaceResponse>(item));
+                ordersResult.Add(CallResult.Ok(item));
         }
 
         if (ordersResult.All(x => !x.Success))
-            return result.AsErrorWithData(new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All orders failed")), ordersResult.ToArray());
+            return HttpResult.Fail<CallResult<OKXOrderPlaceResponse>[]>(result, new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All orders failed")), ordersResult.ToArray());
 
-        return result.As(ordersResult.ToArray());
+        return HttpResult.Ok(result, ordersResult.ToArray());
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXOrderCancelResponse>> CancelOrderAsync(string symbol, long? orderId = null, string? clientOrderId = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXOrderCancelResponse>> CancelOrderAsync(string symbol, long? orderId = null, string? clientOrderId = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             {"instId", symbol },
         };
-        parameters.AddOptionalParameter("ordId", orderId?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("clOrdId", clientOrderId);
+        parameters.Add("ordId", orderId?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("clOrdId", clientOrderId);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/trade/cancel-order", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/trade/cancel-order", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(60, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         var result = await _baseClient.SendRawAsync<OKXRestApiResponse<OKXOrderCancelResponse[]>>(request, parameters, ct, rateLimitKeySuffix: symbol).ConfigureAwait(false);
 
-        if (!result)
-            return result.As<OKXOrderCancelResponse>(default);
+        if (!result.Success)
+            return HttpResult.Fail<OKXOrderCancelResponse>(result);
 
         if (result.Data.ErrorCode != 0 && result.Data.ErrorCode != 1)
-            return result.AsError<OKXOrderCancelResponse>(new ServerError(result.Data.ErrorCode, _baseClient.GetErrorInfo(result.Data.ErrorCode, result.Data.ErrorMessage)));
+            return HttpResult.Fail<OKXOrderCancelResponse>(result, new ServerError(result.Data.ErrorCode, _baseClient.GetErrorInfo(result.Data.ErrorCode, result.Data.ErrorMessage)));
 
         var order = result.Data.Data?.FirstOrDefault();
         if (order == null)
             // Shouldn't happen with error code 0/1
-            return result.AsError<OKXOrderCancelResponse>(new ServerError(ErrorInfo.Unknown));
+            return HttpResult.Fail<OKXOrderCancelResponse>(result, new ServerError(ErrorInfo.Unknown));
 
         if (order.Code != 0)
-            return result.AsErrorWithData<OKXOrderCancelResponse>(new ServerError(order.Code, _baseClient.GetErrorInfo(order.Code, order.Message)), order);
+            return HttpResult.Fail<OKXOrderCancelResponse>(result, new ServerError(order.Code, _baseClient.GetErrorInfo(order.Code, order.Message)), order);
 
-        return result.As(result.Data.Data!.First());
+        return HttpResult.Ok(result, result.Data.Data!.First());
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXCancelAllAfterResponse>> CancelAllAfterAsync(TimeSpan timeout, string? tag = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXCancelAllAfterResponse>> CancelAllAfterAsync(TimeSpan timeout, string? tag = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptional("timeOut", (int)timeout.TotalSeconds);
-        parameters.AddOptional("tag", tag);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("timeOut", (int)timeout.TotalSeconds);
+        parameters.Add("tag", tag);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/trade/cancel-all-after", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/trade/cancel-all-after", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(1, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXCancelAllAfterResponse>(request, parameters, ct, rateLimitKeySuffix: tag ?? "").ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXOrderCancelResponse[]>> CancelMultipleOrdersAsync(IEnumerable<OKXOrderCancelRequest> orders, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXOrderCancelResponse[]>> CancelMultipleOrdersAsync(IEnumerable<OKXOrderCancelRequest> orders, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.SetBody(orders.ToArray());
+        var parameters = new Parameters(orders.ToArray(), OKXExchange._parameterSerializationSettings);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/trade/cancel-batch-orders", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/trade/cancel-batch-orders", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(300, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         var result = await _baseClient.SendRawAsync<OKXRestApiResponse<OKXOrderCancelResponse[]>>(request, parameters, ct).ConfigureAwait(false);
-        if (!result)
-            return result.AsError<OKXOrderCancelResponse[]>(result.Error!);
+        if (!result.Success)
+            return HttpResult.Fail<OKXOrderCancelResponse[]>(result);
 
         if (result.Data.ErrorCode > 0 && result.Data.ErrorCode != 2)
-            return result.AsError<OKXOrderCancelResponse[]>(new ServerError(result.Data.ErrorCode, _baseClient.GetErrorInfo(result.Data.ErrorCode, result.Data.ErrorMessage!)));
+            return HttpResult.Fail<OKXOrderCancelResponse[]>(result, new ServerError(result.Data.ErrorCode, _baseClient.GetErrorInfo(result.Data.ErrorCode, result.Data.ErrorMessage!)));
 
-        return result.As<OKXOrderCancelResponse[]>(result.Data.Data);
+        return HttpResult.Ok<OKXOrderCancelResponse[]>(result, result.Data.Data!);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXOrderAmendResponse>> AmendOrderAsync(
+    public virtual async Task<HttpResult<OKXOrderAmendResponse>> AmendOrderAsync(
         string symbol,
         long? orderId = null,
         string? clientOrderId = null,
@@ -260,44 +261,42 @@ internal class OKXRestClientUnifiedApiTrading : IOKXRestClientUnifiedApiTrading
         int? priceAmendType = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "instId", symbol },
         };
-        parameters.AddOptionalParameter("ordId", orderId?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("clOrdId", clientOrderId);
-        parameters.AddOptionalParameter("cxlOnFail", cancelOnFail);
-        parameters.AddOptionalParameter("reqId", requestId);
-        parameters.AddOptionalParameter("newSz", newQuantity?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("newPx", newPrice?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("ordId", orderId?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("clOrdId", clientOrderId);
+        parameters.Add("cxlOnFail", cancelOnFail);
+        parameters.Add("reqId", requestId);
+        parameters.Add("newSz", newQuantity?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("newPx", newPrice?.ToString(CultureInfo.InvariantCulture));
 
-        parameters.AddOptionalParameter("newTpTriggerPx", newTriggerPrice?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("newTpOrdPx", newTakeProfitOrderPrice?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("newSlTriggerPx", newStopLossTriggerPrice?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("newSlOrdPx", newStopLossOrderPrice?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("newTpTriggerPx", newTriggerPrice?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("newTpOrdPx", newTakeProfitOrderPrice?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("newSlTriggerPx", newStopLossTriggerPrice?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("newSlOrdPx", newStopLossOrderPrice?.ToString(CultureInfo.InvariantCulture));
 
-        parameters.AddOptionalParameter("newTpTriggerPxType", EnumConverter.GetString(newTakeProfitPriceTriggerType));
-        parameters.AddOptionalParameter("newSlTriggerPxType", EnumConverter.GetString(newStopLossPriceTriggerType));
-        parameters.AddOptionalParameter("pxAmendType", priceAmendType);
+        parameters.Add("newTpTriggerPxType", EnumConverter.GetString(newTakeProfitPriceTriggerType));
+        parameters.Add("newSlTriggerPxType", EnumConverter.GetString(newStopLossPriceTriggerType));
+        parameters.Add("pxAmendType", priceAmendType);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/trade/amend-order", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/trade/amend-order", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(60, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXOrderAmendResponse>(request, parameters, ct, rateLimitKeySuffix: symbol).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXOrderAmendResponse[]>> AmendMultipleOrdersAsync(IEnumerable<OKXOrderAmendRequest> orders, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXOrderAmendResponse[]>> AmendMultipleOrdersAsync(IEnumerable<OKXOrderAmendRequest> orders, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.SetBody(orders.ToArray());
-
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/trade/amend-batch-orders", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var parameters = new Parameters(orders.ToArray(), OKXExchange._parameterSerializationSettings);
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/trade/amend-batch-orders", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(300, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXOrderAmendResponse[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXClosePositionResponse>> ClosePositionAsync(
+    public virtual async Task<HttpResult<OKXClosePositionResponse>> ClosePositionAsync(
         string symbol,
         MarginMode marginMode,
         PositionSide? positionSide = null,
@@ -306,41 +305,41 @@ internal class OKXRestClientUnifiedApiTrading : IOKXRestClientUnifiedApiTrading
         string? clientOrderId = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             {"instId", symbol },
             {"tag", LibraryHelpers.GetClientReference(() => _baseClient.ClientOptions.BrokerId, _baseClient.Exchange) }
         };
-        parameters.AddOptional("clOrdId", clientOrderId);
-        parameters.AddEnum("mgnMode", marginMode);
-        parameters.AddOptionalEnum("posSide", positionSide);
-        parameters.AddOptionalParameter("ccy", asset);
-        parameters.AddOptionalParameter("autoCxl", autoCancel);
+        parameters.Add("clOrdId", clientOrderId);
+        parameters.Add("mgnMode", marginMode);
+        parameters.Add("posSide", positionSide);
+        parameters.Add("ccy", asset);
+        parameters.Add("autoCxl", autoCancel);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/trade/close-position", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/trade/close-position", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXClosePositionResponse>(request, parameters, ct, rateLimitKeySuffix: symbol).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXOrder>> GetOrderDetailsAsync(
+    public virtual async Task<HttpResult<OKXOrder>> GetOrderDetailsAsync(
         string symbol,
         long? orderId = null,
         string? clientOrderId = null,
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             {"instId", symbol },
         };
-        parameters.AddOptionalParameter("ordId", orderId?.ToString());
-        parameters.AddOptionalParameter("clOrdId", clientOrderId);
+        parameters.Add("ordId", orderId?.ToString());
+        parameters.Add("clOrdId", clientOrderId);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/trade/order", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/trade/order", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(60, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXOrder>(request, parameters, ct, rateLimitKeySuffix: symbol).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXOrder[]>> GetOrdersAsync(
+    public virtual async Task<HttpResult<OKXOrder[]>> GetOrdersAsync(
         InstrumentType? instrumentType = null,
         string? symbol = null,
         string? underlying = null,
@@ -355,25 +354,25 @@ internal class OKXRestClientUnifiedApiTrading : IOKXRestClientUnifiedApiTrading
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalParameter("uly", underlying);
-        parameters.AddOptionalParameter("before", fromId);
-        parameters.AddOptionalParameter("after", toId);
-        parameters.AddOptionalParameter("limit", limit.ToString());
-        parameters.AddOptionalParameter("instFamily", instrumentFamily);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instId", symbol);
+        parameters.Add("uly", underlying);
+        parameters.Add("before", fromId);
+        parameters.Add("after", toId);
+        parameters.Add("limit", limit.ToString());
+        parameters.Add("instFamily", instrumentFamily);
 
-        parameters.AddOptionalEnum("instType", instrumentType);
-        parameters.AddOptionalEnum("ordType", orderType);
-        parameters.AddOptionalEnum("state", state);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("ordType", orderType);
+        parameters.Add("state", state);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/trade/orders-pending", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/trade/orders-pending", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(60, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXOrder[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXOrder[]>> GetOrderHistoryAsync(
+    public virtual async Task<HttpResult<OKXOrder[]>> GetOrderHistoryAsync(
         InstrumentType instrumentType,
         string? symbol = null,
         string? underlying = null,
@@ -391,27 +390,27 @@ internal class OKXRestClientUnifiedApiTrading : IOKXRestClientUnifiedApiTrading
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("instType", instrumentType);
-        parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalParameter("uly", underlying);
-        parameters.AddOptionalParameter("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("limit", limit.ToString());
-        parameters.AddOptionalParameter("after", fromId);
-        parameters.AddOptionalParameter("before", toId);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("instId", symbol);
+        parameters.Add("uly", underlying);
+        parameters.Add("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("limit", limit.ToString());
+        parameters.Add("after", fromId);
+        parameters.Add("before", toId);
 
-        parameters.AddOptionalEnum("ordType", orderType);
-        parameters.AddOptionalEnum("state", state);
-        parameters.AddOptionalEnum("category", category);
+        parameters.Add("ordType", orderType);
+        parameters.Add("state", state);
+        parameters.Add("category", category);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/trade/orders-history", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/trade/orders-history", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(40, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXOrder[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXOrder[]>> GetOrderArchiveAsync(
+    public virtual async Task<HttpResult<OKXOrder[]>> GetOrderArchiveAsync(
         InstrumentType instrumentType,
         string? symbol = null,
         string? underlying = null,
@@ -429,28 +428,28 @@ internal class OKXRestClientUnifiedApiTrading : IOKXRestClientUnifiedApiTrading
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("instType", instrumentType);
-        parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalParameter("uly", underlying);
-        parameters.AddOptionalParameter("instFamily", instrumentFamily);
-        parameters.AddOptionalParameter("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("limit", limit.ToString());
-        parameters.AddOptionalParameter("after", fromId);
-        parameters.AddOptionalParameter("before", toId);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("instId", symbol);
+        parameters.Add("uly", underlying);
+        parameters.Add("instFamily", instrumentFamily);
+        parameters.Add("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("limit", limit.ToString());
+        parameters.Add("after", fromId);
+        parameters.Add("before", toId);
 
-        parameters.AddOptionalEnum("ordType", orderType);
-        parameters.AddOptionalEnum("state", state);
-        parameters.AddOptionalEnum("category", category);
+        parameters.Add("ordType", orderType);
+        parameters.Add("state", state);
+        parameters.Add("category", category);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/trade/orders-history-archive", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/trade/orders-history-archive", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXOrder[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXTransaction[]>> GetUserTradesAsync(
+    public virtual async Task<HttpResult<OKXTransaction[]>> GetUserTradesAsync(
         InstrumentType? instrumentType = null,
         string? symbol = null,
         string? underlying = null,
@@ -466,25 +465,25 @@ internal class OKXRestClientUnifiedApiTrading : IOKXRestClientUnifiedApiTrading
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddOptionalEnum("instType", instrumentType);
-        parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalParameter("uly", underlying);
-        parameters.AddOptionalParameter("ordId", orderId?.ToString());
-        parameters.AddOptionalParameter("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("after", fromId);
-        parameters.AddOptionalParameter("before", toId);
-        parameters.AddOptionalParameter("limit", limit.ToString());
-        parameters.AddOptionalParameter("instFamily", instrumentFamily);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("instId", symbol);
+        parameters.Add("uly", underlying);
+        parameters.Add("ordId", orderId?.ToString());
+        parameters.Add("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("after", fromId);
+        parameters.Add("before", toId);
+        parameters.Add("limit", limit.ToString());
+        parameters.Add("instFamily", instrumentFamily);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/trade/fills", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/trade/fills", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(60, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXTransaction[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXTransaction[]>> GetUserTradesArchiveAsync(
+    public virtual async Task<HttpResult<OKXTransaction[]>> GetUserTradesArchiveAsync(
         InstrumentType instrumentType,
         string? symbol = null,
         string? underlying = null,
@@ -500,25 +499,25 @@ internal class OKXRestClientUnifiedApiTrading : IOKXRestClientUnifiedApiTrading
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("instType", instrumentType);
-        parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalParameter("uly", underlying);
-        parameters.AddOptionalParameter("ordId", orderId?.ToString());
-        parameters.AddOptionalParameter("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("after", fromId);
-        parameters.AddOptionalParameter("before", toId);
-        parameters.AddOptionalParameter("limit", limit.ToString());
-        parameters.AddOptionalParameter("instFamily", instrumentFamily);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("instType", instrumentType);
+        parameters.Add("instId", symbol);
+        parameters.Add("uly", underlying);
+        parameters.Add("ordId", orderId?.ToString());
+        parameters.Add("begin", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("end", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("after", fromId);
+        parameters.Add("before", toId);
+        parameters.Add("limit", limit.ToString());
+        parameters.Add("instFamily", instrumentFamily);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/trade/fills-history", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/trade/fills-history", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(10, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXTransaction[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAlgoOrderResponse>> PlaceAlgoOrderAsync(
+    public virtual async Task<HttpResult<OKXAlgoOrderResponse>> PlaceAlgoOrderAsync(
         string symbol,
         TradeMode tradeMode,
         OrderSide orderSide,
@@ -565,83 +564,81 @@ internal class OKXRestClientUnifiedApiTrading : IOKXRestClientUnifiedApiTrading
 
         CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection {
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings) {
             {"instId", symbol },
             {"tag", LibraryHelpers.GetClientReference(() => _baseClient.ClientOptions.BrokerId, _baseClient.Exchange) }
         };
-        parameters.AddOptional("clOrdId", clientOrderId);
-        parameters.AddEnum("tdMode", tradeMode);
-        parameters.AddEnum("side", orderSide);
-        parameters.AddEnum("ordType", algoOrderType);
-        parameters.AddOptionalString("sz", quantity);
-        parameters.AddOptionalParameter("ccy", asset);
-        parameters.AddOptionalParameter("reduceOnly", reduceOnly);
+        parameters.Add("clOrdId", clientOrderId);
+        parameters.Add("tdMode", tradeMode);
+        parameters.Add("side", orderSide);
+        parameters.Add("ordType", algoOrderType);
+        parameters.Add("sz", quantity);
+        parameters.Add("ccy", asset);
+        parameters.Add("reduceOnly", reduceOnly);
 
-        parameters.AddOptionalEnum("posSide", positionSide);
-        parameters.AddOptionalParameter("tgtCcy", EnumConverter.GetString(quantityType));
+        parameters.Add("posSide", positionSide);
+        parameters.Add("tgtCcy", EnumConverter.GetString(quantityType));
 
-        parameters.AddOptionalEnum("tpTriggerPxType", tpTriggerPxType);
-        parameters.AddOptionalParameter("tpTriggerPx", tpTriggerPrice?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("tpOrdPx", tpOrderPrice?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalEnum("slTriggerPxType", slTriggerPxType);
-        parameters.AddOptionalParameter("slTriggerPx", slTriggerPrice?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("slOrdPx", slOrderPrice?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("tpTriggerPxType", tpTriggerPxType);
+        parameters.Add("tpTriggerPx", tpTriggerPrice?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("tpOrdPx", tpOrderPrice?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("slTriggerPxType", slTriggerPxType);
+        parameters.Add("slTriggerPx", slTriggerPrice?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("slOrdPx", slOrderPrice?.ToString(CultureInfo.InvariantCulture));
 
-        parameters.AddOptionalParameter("triggerPx", triggerPrice?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("orderPx", orderPrice?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalEnum("advanceOrdType", advancedOrderType);
+        parameters.Add("triggerPx", triggerPrice?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("orderPx", orderPrice?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("advanceOrdType", advancedOrderType);
 
-        parameters.AddOptionalEnum("pxVar", pxVar);
-        parameters.AddOptionalParameter("pxSpread", priceRatio?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("szLimit", sizeLimit?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("pxLimit", priceLimit?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("cxlOnClosePos", cancelOnClose);
-        parameters.AddOptionalParameter("quickMgnType", EnumConverter.GetString(quickMarginType));
+        parameters.Add("pxVar", pxVar);
+        parameters.Add("pxSpread", priceRatio?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("szLimit", sizeLimit?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("pxLimit", priceLimit?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("cxlOnClosePos", cancelOnClose);
+        parameters.Add("quickMgnType", EnumConverter.GetString(quickMarginType));
 
-        parameters.AddOptionalParameter("callbackRatio", callbackRatio?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("callbackSpread", callbackSpread?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("activePx", activePx?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("callbackRatio", callbackRatio?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("callbackSpread", callbackSpread?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("activePx", activePx?.ToString(CultureInfo.InvariantCulture));
 
-        parameters.AddOptionalParameter("timeInterval", timeInterval?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("closeFraction", closeFraction?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("timeInterval", timeInterval?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("closeFraction", closeFraction?.ToString(CultureInfo.InvariantCulture));
 
-        parameters.AddOptionalEnum("chaseType", chaseType);
-        parameters.AddOptionalString("chaseVal", chaseValue);
-        parameters.AddOptionalEnum("maxChaseType", maxChaseType);
-        parameters.AddOptionalString("maxChaseVal", maxChaseValue);
-        parameters.AddOptional("tradeQuoteCcy", tradeQuoteAsset);
+        parameters.Add("chaseType", chaseType);
+        parameters.Add("chaseVal", chaseValue);
+        parameters.Add("maxChaseType", maxChaseType);
+        parameters.Add("maxChaseVal", maxChaseValue);
+        parameters.Add("tradeQuoteCcy", tradeQuoteAsset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/trade/order-algo", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/trade/order-algo", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         var result = await _baseClient.SendRawAsync<OKXRestApiResponse<OKXAlgoOrderResponse[]>>(request, parameters, ct).ConfigureAwait(false);
-        if (!result)
-            return result.As<OKXAlgoOrderResponse>(default);
+        if (!result.Success)
+            return HttpResult.Fail<OKXAlgoOrderResponse>(result);
 
         var detailed = result.Data.Data?.FirstOrDefault();
         if (result.Data.ErrorCode > 0)
         {
             if (detailed != null)
-                return result.AsError<OKXAlgoOrderResponse>(new ServerError(detailed.Code, _baseClient.GetErrorInfo(detailed.Code, detailed.Message)));
+                return HttpResult.Fail<OKXAlgoOrderResponse>(result, new ServerError(detailed.Code, _baseClient.GetErrorInfo(detailed.Code, detailed.Message)));
 
-            return result.AsError<OKXAlgoOrderResponse>(new ServerError(result.Data.ErrorCode, _baseClient.GetErrorInfo(result.Data.ErrorCode, result.Data.ErrorMessage!)));
+            return HttpResult.Fail<OKXAlgoOrderResponse>(result, new ServerError(result.Data.ErrorCode, _baseClient.GetErrorInfo(result.Data.ErrorCode, result.Data.ErrorMessage!)));
         }
 
-        return result.As<OKXAlgoOrderResponse>(detailed);
+        return HttpResult.Ok(result, detailed!);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAlgoOrderResponse>> CancelAlgoOrderAsync(IEnumerable<OKXAlgoOrderRequest> orders, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXAlgoOrderResponse>> CancelAlgoOrderAsync(IEnumerable<OKXAlgoOrderRequest> orders, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.SetBody(orders.ToArray());
-
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/trade/cancel-algos", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var parameters = new Parameters(orders.ToArray(), OKXExchange._parameterSerializationSettings);
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/trade/cancel-algos", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXAlgoOrderResponse>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAlgoOrder[]>> GetAlgoOrderListAsync(
+    public virtual async Task<HttpResult<OKXAlgoOrder[]>> GetAlgoOrderListAsync(
         AlgoOrderType algoOrderType,
         string? algoId = null,
         InstrumentType? instrumentType = null,
@@ -654,22 +651,22 @@ internal class OKXRestClientUnifiedApiTrading : IOKXRestClientUnifiedApiTrading
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("ordType", algoOrderType);
-        parameters.AddOptionalParameter("algoId", algoId);
-        parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("limit", limit.ToString());
-        parameters.AddOptionalEnum("instType", instrumentType);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("ordType", algoOrderType);
+        parameters.Add("algoId", algoId);
+        parameters.Add("instId", symbol);
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("limit", limit.ToString());
+        parameters.Add("instType", instrumentType);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/trade/orders-algo-pending", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/trade/orders-algo-pending", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXAlgoOrder[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAlgoOrder[]>> GetAlgoOrderHistoryAsync(
+    public virtual async Task<HttpResult<OKXAlgoOrder[]>> GetAlgoOrderHistoryAsync(
         AlgoOrderType algoOrderType,
         AlgoOrderState? algoOrderState = null,
         string? algoId = null,
@@ -683,116 +680,116 @@ internal class OKXRestClientUnifiedApiTrading : IOKXRestClientUnifiedApiTrading
         if (limit < 1 || limit > 100)
             throw new ArgumentException("Limit can be between 1-100.");
 
-        var parameters = new ParameterCollection();
-        parameters.AddEnum("ordType", algoOrderType);
-        parameters.AddOptionalParameter("algoId", algoId);
-        parameters.AddOptionalParameter("instId", symbol);
-        parameters.AddOptionalParameter("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("limit", limit.ToString());
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("ordType", algoOrderType);
+        parameters.Add("algoId", algoId);
+        parameters.Add("instId", symbol);
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("limit", limit.ToString());
 
-        parameters.AddOptionalEnum("state", algoOrderState);
-        parameters.AddOptionalEnum("instType", instrumentType);
+        parameters.Add("state", algoOrderState);
+        parameters.Add("instType", instrumentType);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/trade/orders-algo-history", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/trade/orders-algo-history", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXAlgoOrder[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAlgoOrder>> GetAlgoOrderAsync(string? algoId = null, string? clientAlgoId = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXAlgoOrder>> GetAlgoOrderAsync(string? algoId = null, string? clientAlgoId = null, CancellationToken ct = default)
     {
         if ((algoId == null) == (clientAlgoId == null))
             throw new ArgumentException("Either algoId or clientAlgoId needs to be provided");
 
-        var parameters = new ParameterCollection();
-        parameters.AddOptional("algoId", algoId);
-        parameters.AddOptional("algoClOrdId", clientAlgoId);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("algoId", algoId);
+        parameters.Add("algoClOrdId", clientAlgoId);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/trade/order-algo", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/trade/order-algo", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXAlgoOrder>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAccountRateLimit[]>> GetAccountRateLimitAsync(CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXAccountRateLimit[]>> GetAccountRateLimitAsync(CancellationToken ct = default)
     {
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/trade/account-rate-limit", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/trade/account-rate-limit", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(1, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXAccountRateLimit[]>(request, null, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXOneClickRepayCurrencyList[]>> GetOneClickRepayCurrencyListAsync(string? debtType = null, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXOneClickRepayCurrencyList[]>> GetOneClickRepayCurrencyListAsync(string? debtType = null, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptional("debtType", debtType);
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("debtType", debtType);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/trade/one-click-repay-currency-list", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/trade/one-click-repay-currency-list", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(1, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXOneClickRepayCurrencyList[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXOneClickRepayCurrencyListV2[]>> GetOneClickRepayCurrencyListV2Async(CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXOneClickRepayCurrencyListV2[]>> GetOneClickRepayCurrencyListV2Async(CancellationToken ct = default)
     {
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/trade/one-click-repay-currency-list-v2", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/trade/one-click-repay-currency-list-v2", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(1, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXOneClickRepayCurrencyListV2[]>(request, null, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXOneClickRepayResponse[]>> OneClickRepayAsync(string debtAsset, string repayAsset, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXOneClickRepayResponse[]>> OneClickRepayAsync(string debtAsset, string repayAsset, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
         parameters.Add("debtCcy", debtAsset);
         parameters.Add("repayCcy", repayAsset);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/trade/one-click-repay", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/trade/one-click-repay", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(1, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXOneClickRepayResponse[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXOneClickRepayResponseV2[]>> OneClickRepayV2Async(string debtAsset, IEnumerable<string> repayAssetList, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXOneClickRepayResponseV2[]>> OneClickRepayV2Async(string debtAsset, IEnumerable<string> repayAssetList, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
         parameters.Add("debtCcy", debtAsset);
         parameters.Add("repayCcyList", repayAssetList);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/trade/one-click-repay-v2", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/trade/one-click-repay-v2", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(1, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXOneClickRepayResponseV2[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXOneClickRepayHistory[]>> GetOneClickRepayHistoryAsync(DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXOneClickRepayHistory[]>> GetOneClickRepayHistoryAsync(DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptional("after", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptional("before", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptional("limit", limit.ToString(CultureInfo.InvariantCulture));
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("limit", limit.ToString(CultureInfo.InvariantCulture));
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/trade/one-click-repay-history", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/trade/one-click-repay-history", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(1, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXOneClickRepayHistory[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXOneClickRepayHistoryV2[]>> GetOneClickRepayHistoryV2Async(DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default)
+    public virtual async Task<HttpResult<OKXOneClickRepayHistoryV2[]>> GetOneClickRepayHistoryV2Async(DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default)
     {
-        var parameters = new ParameterCollection();
-        parameters.AddOptional("after", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptional("before", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptional("limit", limit.ToString(CultureInfo.InvariantCulture));
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
+        parameters.Add("after", DateTimeConverter.ConvertToMilliseconds(startTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("before", DateTimeConverter.ConvertToMilliseconds(endTime)?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("limit", limit.ToString(CultureInfo.InvariantCulture));
 
-        var request = _definitions.GetOrCreate(HttpMethod.Get, "api/v5/trade/one-click-repay-history-v2", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "api/v5/trade/one-click-repay-history-v2", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(1, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendAsync<OKXOneClickRepayHistoryV2[]>(request, parameters, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<WebCallResult<OKXAlgoOrderAmendResponse>> AmendAlgoOrderAsync(
+    public virtual async Task<HttpResult<OKXAlgoOrderAmendResponse>> AmendAlgoOrderAsync(
         string symbol,
         string? algoId = null,
         string? clientAlgoId = null,
@@ -810,23 +807,23 @@ internal class OKXRestClientUnifiedApiTrading : IOKXRestClientUnifiedApiTrading
         if ((algoId == null) == (clientAlgoId == null))
             throw new ArgumentException("Either algoId or clientAlgoId needs to be provided");
 
-        var parameters = new ParameterCollection
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "instId", symbol },
         };
-        parameters.AddOptional("algoId", algoId?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptional("algoClOrdId", clientAlgoId);
-        parameters.AddOptional("cxlOnFail", cancelOnFail);
-        parameters.AddOptional("reqId", requestId);
-        parameters.AddOptional("newSz", newQuantity?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptional("newTpTriggerPx", newTakeProfitTriggerPrice?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptional("newTpOrdPx", newTakeProfitOrderPrice?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptional("newSlTriggerPx", newStopLossTriggerPrice?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptional("newSlOrdPx", newStopLossOrderPrice?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalEnum("newTpTriggerPxType", newTakeProfitPriceTriggerType);
-        parameters.AddOptionalEnum("newSlTriggerPxType", newStopLossPriceTriggerType);
+        parameters.Add("algoId", algoId?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("algoClOrdId", clientAlgoId);
+        parameters.Add("cxlOnFail", cancelOnFail);
+        parameters.Add("reqId", requestId);
+        parameters.Add("newSz", newQuantity?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("newTpTriggerPx", newTakeProfitTriggerPrice?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("newTpOrdPx", newTakeProfitOrderPrice?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("newSlTriggerPx", newStopLossTriggerPrice?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("newSlOrdPx", newStopLossOrderPrice?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("newTpTriggerPxType", newTakeProfitPriceTriggerType);
+        parameters.Add("newSlTriggerPxType", newStopLossPriceTriggerType);
 
-        var request = _definitions.GetOrCreate(HttpMethod.Post, "api/v5/trade/amend-algos", OKXExchange.RateLimiter.EndpointGate, 1, true,
+        var request = _definitions.GetOrCreate(HttpMethod.Post, _baseClient.BaseAddress, "api/v5/trade/amend-algos", OKXExchange.RateLimiter.EndpointGate, 1, true,
             limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(2), RateLimitWindowType.Sliding, keySelector: SingleLimitGuard.PerApiKey));
         return await _baseClient.SendGetSingleAsync<OKXAlgoOrderAmendResponse>(request, parameters, ct).ConfigureAwait(false);
     }

--- a/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApi.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApi.cs
@@ -69,7 +69,12 @@ internal partial class OKXSocketClientUnifiedApi : SocketApiClient<OKXEnvironmen
 
     /// <inheritdoc />
     public override string FormatSymbol(string baseAsset, string quoteAsset, TradingMode tradingMode, DateTime? deliverTime = null)
-        => OKXExchange.FormatSymbol(baseAsset, quoteAsset, tradingMode, deliverTime);
+    {
+        if (EnvironmentName == OKXEnvironment.Europe.Name)
+            return OKXExchange.FormatSymbolEurope(baseAsset, quoteAsset, tradingMode, deliverTime);
+        else
+            return OKXExchange.FormatSymbol(baseAsset, quoteAsset, tradingMode, deliverTime);
+    }
 
     internal Task<WebSocketResult<UpdateSubscription>> SubscribeInternalAsync(string url, Subscription subscription, CancellationToken ct)
     {

--- a/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApi.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApi.cs
@@ -32,7 +32,7 @@ internal partial class OKXSocketClientUnifiedApi : SocketApiClient<OKXEnvironmen
     #region ctor
 
     internal OKXSocketClientUnifiedApi(ILogger logger, OKXSocketOptions options) :
-        base(logger, options.Environment.SocketAddress, options, options.UnifiedOptions)
+        base(logger, OKXExchange.Metadata.Id, options.Environment.SocketAddress, options, options.UnifiedOptions)
     {
         Account = new OKXSocketClientUnifiedApiAccount(logger, this);
         ExchangeData = new OKXSocketClientUnifiedApiExchangeData(logger, this);
@@ -71,7 +71,7 @@ internal partial class OKXSocketClientUnifiedApi : SocketApiClient<OKXEnvironmen
     public override string FormatSymbol(string baseAsset, string quoteAsset, TradingMode tradingMode, DateTime? deliverTime = null)
         => OKXExchange.FormatSymbol(baseAsset, quoteAsset, tradingMode, deliverTime);
 
-    internal Task<CallResult<UpdateSubscription>> SubscribeInternalAsync(string url, Subscription subscription, CancellationToken ct)
+    internal Task<WebSocketResult<UpdateSubscription>> SubscribeInternalAsync(string url, Subscription subscription, CancellationToken ct)
     {
         return SubscribeAsync(url, subscription, ct);
     }
@@ -82,27 +82,27 @@ internal partial class OKXSocketClientUnifiedApi : SocketApiClient<OKXEnvironmen
         if (_demoTrading && !address.EndsWith("brokerId=9999"))
             address += "?brokerId=9999";
 
-        return Task.FromResult(new CallResult<string?>(address));
+        return Task.FromResult(CallResult.Ok<string?>(address));
     }
 
-    internal async Task<CallResult<T>> QueryInternalAsync<T>(string url, string operation, Dictionary<string, object> parameters, bool authenticated, int weight, CancellationToken ct = default)
+    internal async Task<QueryResult<T>> QueryInternalAsync<T>(string url, string operation, Parameters parameters, bool authenticated, int weight, CancellationToken ct = default)
     {
         var query = new OKXIdQuery<T>(this, operation, new object[] { parameters }, authenticated, weight);
         var result = await QueryAsync(url, query, ct).ConfigureAwait(false);
-        if (!result)
-            return result.AsError<T>(result.Error!);
+        if (!result.Success)
+            return QueryResult.Fail<T>(result);
 
-        return result.As(result.Data.Data.First());
+        return QueryResult.Ok(result, result.Data.Data.First());
     }
 
-    internal async Task<CallResult<T[]>> QueryInternalAsync<T>(string url, string operation, IEnumerable<object> data, bool authenticated, int weight, CancellationToken ct = default)
+    internal async Task<QueryResult<T[]>> QueryInternalAsync<T>(string url, string operation, IEnumerable<object> data, bool authenticated, int weight, CancellationToken ct = default)
     {
         var query = new OKXIdQuery<T>(this, operation, data.ToArray(), authenticated, weight);
         var result = await QueryAsync(url, query, ct).ConfigureAwait(false);
-        if (!result)
-            return result.AsError<T[]>(result.Error!);
+        if (!result.Success)
+            return QueryResult.Fail<T[]>(result);
 
-        return result.As(result.Data.Data);
+        return QueryResult.Ok(result, result.Data.Data);
     }
 
     internal string GetUri(string path) => BaseAddress.Trim('/') + path;

--- a/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApi.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApi.cs
@@ -31,12 +31,12 @@ internal partial class OKXSocketClientUnifiedApi : SocketApiClient<OKXEnvironmen
 
     #region ctor
 
-    internal OKXSocketClientUnifiedApi(ILogger logger, OKXSocketOptions options) :
-        base(logger, OKXExchange.Metadata.Id, options.Environment.SocketAddress, options, options.UnifiedOptions)
+    internal OKXSocketClientUnifiedApi(ILoggerFactory? loggerFactory, OKXSocketOptions options) :
+        base(loggerFactory, OKXExchange.Metadata.Id, options.Environment.SocketAddress, options, options.UnifiedOptions)
     {
-        Account = new OKXSocketClientUnifiedApiAccount(logger, this);
-        ExchangeData = new OKXSocketClientUnifiedApiExchangeData(logger, this);
-        Trading = new OKXSocketClientUnifiedApiTrading(logger, this);
+        Account = new OKXSocketClientUnifiedApiAccount(_logger, this);
+        ExchangeData = new OKXSocketClientUnifiedApiExchangeData(_logger, this);
+        Trading = new OKXSocketClientUnifiedApiTrading(_logger, this);
 
         _demoTrading = options.Environment.Name == TradeEnvironmentNames.Testnet;
 

--- a/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApiAccount.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApiAccount.cs
@@ -24,7 +24,7 @@ internal class OKXSocketClientUnifiedApiAccount : IOKXSocketClientUnifiedApiAcco
     #endregion
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToAccountUpdatesAsync(
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToAccountUpdatesAsync(
         string? asset,
         bool regularUpdates,
         Action<DataEvent<OKXAccountBalance>> onData,
@@ -61,7 +61,7 @@ internal class OKXSocketClientUnifiedApiAccount : IOKXSocketClientUnifiedApiAcco
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToBalanceAndPositionUpdatesAsync(
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToBalanceAndPositionUpdatesAsync(
         Action<DataEvent<OKXPositionAndBalanceUpdate>> onData,
         CancellationToken ct = default)
     {
@@ -91,7 +91,7 @@ internal class OKXSocketClientUnifiedApiAccount : IOKXSocketClientUnifiedApiAcco
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToDepositUpdatesAsync(
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToDepositUpdatesAsync(
         Action<DataEvent<OKXDepositUpdate>> onData,
         CancellationToken ct = default)
     {
@@ -121,7 +121,7 @@ internal class OKXSocketClientUnifiedApiAccount : IOKXSocketClientUnifiedApiAcco
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToWithdrawalUpdatesAsync(Action<DataEvent<OKXWithdrawalUpdate>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToWithdrawalUpdatesAsync(Action<DataEvent<OKXWithdrawalUpdate>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXWithdrawalUpdate[]>>((receiveTime, originalData, data) =>
         {
@@ -149,7 +149,7 @@ internal class OKXSocketClientUnifiedApiAccount : IOKXSocketClientUnifiedApiAcco
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToGreeksUpdatesAsync(
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToGreeksUpdatesAsync(
         string? asset,
         Action<DataEvent<OKXGreeks[]>> onData, 
         CancellationToken ct = default)

--- a/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApiExchangeData.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApiExchangeData.cs
@@ -26,7 +26,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     #endregion
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(InstrumentType instrumentType, Action<DataEvent<OKXInstrument[]>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(InstrumentType instrumentType, Action<DataEvent<OKXInstrument[]>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXInstrument[]>>((receiveTime, originalData, data) =>
         {
@@ -51,7 +51,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(string symbol, Action<DataEvent<OKXTicker>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(string symbol, Action<DataEvent<OKXTicker>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXTicker[]>>((receiveTime, originalData, data) =>
         {
@@ -81,7 +81,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
 
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXTicker>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXTicker>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXTicker[]>>((receiveTime, originalData, data) =>
         {
@@ -110,7 +110,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToOpenInterestUpdatesAsync(string symbol, Action<DataEvent<OKXOpenInterest>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToOpenInterestUpdatesAsync(string symbol, Action<DataEvent<OKXOpenInterest>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXOpenInterest[]>>((receiveTime, originalData, data) =>
         {
@@ -139,7 +139,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToOpenInterestUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXOpenInterest>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToOpenInterestUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXOpenInterest>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXOpenInterest[]>>((receiveTime, originalData, data) =>
         {
@@ -169,7 +169,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval klineInterval, Action<DataEvent<OKXKline>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval klineInterval, Action<DataEvent<OKXKline>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXKline[]>>((receiveTime, originalData, data) =>
         {
@@ -200,7 +200,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols, KlineInterval klineInterval, Action<DataEvent<OKXKline>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols, KlineInterval klineInterval, Action<DataEvent<OKXKline>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXKline[]>>((receiveTime, originalData, data) =>
         {
@@ -232,7 +232,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<OKXTrade>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<OKXTrade>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXTrade[]>>((receiveTime, originalData, data) =>
         {
@@ -261,7 +261,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXTrade>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXTrade>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXTrade[]>>((receiveTime, originalData, data) =>
         {
@@ -291,7 +291,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToEstimatedPriceUpdatesAsync(InstrumentType instrumentType, string? instrumentFamily, string? symbol, Action<DataEvent<OKXEstimatedPrice>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToEstimatedPriceUpdatesAsync(InstrumentType instrumentType, string? instrumentFamily, string? symbol, Action<DataEvent<OKXEstimatedPrice>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXEstimatedPrice[]>>((receiveTime, originalData, data) =>
         {
@@ -322,7 +322,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToMarkPriceUpdatesAsync(string symbol, Action<DataEvent<OKXMarkPrice>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToMarkPriceUpdatesAsync(string symbol, Action<DataEvent<OKXMarkPrice>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXMarkPrice[]>>((receiveTime, originalData, data) =>
         {
@@ -351,7 +351,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToMarkPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXMarkPrice>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToMarkPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXMarkPrice>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXMarkPrice[]>>((receiveTime, originalData, data) =>
         {
@@ -381,7 +381,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToMarkPriceKlineUpdatesAsync(string symbol, KlineInterval klineInterval, Action<DataEvent<OKXMiniKline[]>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToMarkPriceKlineUpdatesAsync(string symbol, KlineInterval klineInterval, Action<DataEvent<OKXMiniKline[]>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXMiniKline[]>>((receiveTime, originalData, data) =>
         {
@@ -407,7 +407,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToPriceLimitUpdatesAsync(string symbol, Action<DataEvent<OKXLimitPrice>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToPriceLimitUpdatesAsync(string symbol, Action<DataEvent<OKXLimitPrice>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXLimitPrice[]>>((receiveTime, originalData, data) =>
         {
@@ -436,7 +436,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToPriceLimitUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXLimitPrice>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToPriceLimitUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXLimitPrice>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXLimitPrice[]>>((receiveTime, originalData, data) =>
         {
@@ -465,7 +465,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, OrderBookType orderBookType, Action<DataEvent<OKXOrderBook>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, OrderBookType orderBookType, Action<DataEvent<OKXOrderBook>> onData, CancellationToken ct = default)
     {
         var jc = EnumConverter.GetString(orderBookType);
         var subscription = new OKXBookSubscription(_logger, _client, new List<OKXSocketArgs>
@@ -481,7 +481,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, OrderBookType orderBookType, Action<DataEvent<OKXOrderBook>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, OrderBookType orderBookType, Action<DataEvent<OKXOrderBook>> onData, CancellationToken ct = default)
     {
         var jc = EnumConverter.GetString(orderBookType);
         var subscription = new OKXBookSubscription(_logger,
@@ -502,7 +502,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToOptionSummaryUpdatesAsync(string instrumentFamily, Action<DataEvent<OKXOptionSummary[]>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToOptionSummaryUpdatesAsync(string instrumentFamily, Action<DataEvent<OKXOptionSummary[]>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXOptionSummary[]>>((receiveTime, originalData, data) =>
         {
@@ -531,7 +531,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToFundingRateUpdatesAsync(string symbol, Action<DataEvent<OKXFundingRate>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToFundingRateUpdatesAsync(string symbol, Action<DataEvent<OKXFundingRate>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXFundingRate[]>>((receiveTime, originalData, data) =>
         {
@@ -560,7 +560,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToFundingRateUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXFundingRate>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToFundingRateUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXFundingRate>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXFundingRate[]>>((receiveTime, originalData, data) =>
         {
@@ -590,7 +590,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToIndexKlineUpdatesAsync(string symbol, KlineInterval klineInterval, Action<DataEvent<OKXMiniKline[]>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToIndexKlineUpdatesAsync(string symbol, KlineInterval klineInterval, Action<DataEvent<OKXMiniKline[]>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXMiniKline[]>>((receiveTime, originalData, data) =>
         {
@@ -616,7 +616,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToIndexTickerUpdatesAsync(string symbol, Action<DataEvent<OKXIndexTicker>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToIndexTickerUpdatesAsync(string symbol, Action<DataEvent<OKXIndexTicker>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXIndexTicker[]>>((receiveTime, originalData, data) =>
         {
@@ -645,7 +645,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToIndexTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXIndexTicker>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToIndexTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXIndexTicker>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXIndexTicker[]>>((receiveTime, originalData, data) =>
         {
@@ -675,7 +675,7 @@ internal class OKXSocketClientUnifiedApiExchangeData : IOKXSocketClientUnifiedAp
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToSystemStatusUpdatesAsync(Action<DataEvent<OKXStatus>> onData, CancellationToken ct = default)
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToSystemStatusUpdatesAsync(Action<DataEvent<OKXStatus>> onData, CancellationToken ct = default)
     {
         var internalHandler = new Action<DateTime, string?, OKXSocketUpdate<OKXStatus[]>>((receiveTime, originalData, data) =>
         {

--- a/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApiShared.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApiShared.cs
@@ -10,23 +10,23 @@ namespace OKX.Net.Clients.UnifiedApi
     {
         private const string _topicSpotId = "OKXSpot";
         private const string _topicFuturesId = "OKXFutures";
+        private const string _exchangeName = "OKX";
 
-        public string Exchange => OKXExchange.ExchangeName;
         public TradingMode[] SupportedTradingModes { get; } = new[] { TradingMode.Spot, TradingMode.PerpetualLinear, TradingMode.PerpetualInverse, TradingMode.DeliveryLinear, TradingMode.DeliveryInverse };
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
 
         #region Ticker client
-        SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions
-        {
+        SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions(_exchangeName) {
             SupportsMultipleSymbols = true
         };
-        async Task<ExchangeResult<UpdateSubscription>> ITickerSocketClient.SubscribeToTickerUpdatesAsync(SubscribeTickerRequest request, Action<DataEvent<SharedSpotTicker>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> ITickerSocketClient.SubscribeToTickerUpdatesAsync(SubscribeTickerRequest request, Action<DataEvent<SharedSpotTicker>> handler, CancellationToken ct)
         {
-            var validationError = ((ITickerSocketClient)this).SubscribeTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)).ToArray() : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await ExchangeData.SubscribeToTickerUpdatesAsync(symbols, update => handler(update.ToType(new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(request.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, update.Data.Symbol), update.Data.Symbol, update.Data.LastPrice ?? 0, update.Data.HighPrice ?? 0, update.Data.LowPrice ?? 0, update.Data.Volume, update.Data.OpenPrice == null ? null : Math.Round((update.Data.LastPrice ?? 0) / update.Data.OpenPrice.Value * 100 - 100, 2))
@@ -34,18 +34,18 @@ namespace OKX.Net.Clients.UnifiedApi
                 QuoteVolume = update.Data.QuoteVolume
             })), ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Trade client
 
-        EndpointOptions<SubscribeTradeRequest> ITradeSocketClient.SubscribeTradeOptions { get; } = new EndpointOptions<SubscribeTradeRequest>(false);
-        async Task<ExchangeResult<UpdateSubscription>> ITradeSocketClient.SubscribeToTradeUpdatesAsync(SubscribeTradeRequest request, Action<DataEvent<SharedTrade[]>> handler, CancellationToken ct)
+        SubscribeTradeOptions ITradeSocketClient.SubscribeTradeOptions { get; } = new SubscribeTradeOptions(_exchangeName, false);
+        async Task<WebSocketResult<UpdateSubscription>> ITradeSocketClient.SubscribeToTradeUpdatesAsync(SubscribeTradeRequest request, Action<DataEvent<SharedTrade[]>> handler, CancellationToken ct)
         {
-            var validationError = ((ITradeSocketClient)this).SubscribeTradeOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)).ToArray() : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await ExchangeData.SubscribeToTradeUpdatesAsync(symbols, update => handler(update.ToType<SharedTrade[]>(new[] {
@@ -53,32 +53,32 @@ namespace OKX.Net.Clients.UnifiedApi
                 Side = update.Data.Side == OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell
             } })), ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion
 
         #region Book Ticker client
 
-        EndpointOptions<SubscribeBookTickerRequest> IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new EndpointOptions<SubscribeBookTickerRequest>(false)
+        SubscribeBookTickerOptions IBookTickerSocketClient.SubscribeBookTickerOptions { get; } = new SubscribeBookTickerOptions(_exchangeName, false)
         {
             SupportsMultipleSymbols = true
         };
-        async Task<ExchangeResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IBookTickerSocketClient.SubscribeToBookTickerUpdatesAsync(SubscribeBookTickerRequest request, Action<DataEvent<SharedBookTicker>> handler, CancellationToken ct)
         {
-            var validationError = ((IBookTickerSocketClient)this).SubscribeBookTickerOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeBookTickerOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)).ToArray() : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await ExchangeData.SubscribeToTickerUpdatesAsync(symbols, update => handler(update.ToType(new SharedBookTicker(ExchangeSymbolCache.ParseSymbol(request.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, update.Data.Symbol), update.Data.Symbol, update.Data.BestAskPrice ?? 0, update.Data.BestAskQuantity ?? 0, update.Data.BestBidPrice ?? 0, update.Data.BestBidQuantity ?? 0))), ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Kline client
-        SubscribeKlineOptions IKlineSocketClient.SubscribeKlineOptions { get; } = new SubscribeKlineOptions(false,
+        SubscribeKlineOptions IKlineSocketClient.SubscribeKlineOptions { get; } = new SubscribeKlineOptions(_exchangeName, false,
             SharedKlineInterval.OneMinute,
             SharedKlineInterval.ThreeMinutes,
             SharedKlineInterval.FiveMinutes,
@@ -95,51 +95,49 @@ namespace OKX.Net.Clients.UnifiedApi
         {
             SupportsMultipleSymbols = true
         };
-        async Task<ExchangeResult<UpdateSubscription>> IKlineSocketClient.SubscribeToKlineUpdatesAsync(SubscribeKlineRequest request, Action<DataEvent<SharedKline>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IKlineSocketClient.SubscribeToKlineUpdatesAsync(SubscribeKlineRequest request, Action<DataEvent<SharedKline>> handler, CancellationToken ct)
         {
             var interval = (KlineInterval)request.Interval;
-            if (!Enum.IsDefined(typeof(KlineInterval), interval))
-                return new ExchangeResult<UpdateSubscription>(Exchange, ArgumentError.Invalid(nameof(GetKlinesRequest.Interval), "Interval not supported"));
 
-            var validationError = ((IKlineSocketClient)this).SubscribeKlineOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeKlineOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)).ToArray() : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await ExchangeData.SubscribeToKlineUpdatesAsync(symbols, interval, update => handler(update.ToType(
                 new SharedKline(ExchangeSymbolCache.ParseSymbol(request.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, update.Data.Symbol), update.Data.Symbol, update.Data.Time, update.Data.ClosePrice, update.Data.HighPrice, update.Data.LowPrice, update.Data.OpenPrice, update.Data.Volume))), ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Order Book client
-        SubscribeOrderBookOptions IOrderBookSocketClient.SubscribeOrderBookOptions { get; } = new SubscribeOrderBookOptions(false, new[] { 1, 5 })
+        SubscribeOrderBookOptions IOrderBookSocketClient.SubscribeOrderBookOptions { get; } = new SubscribeOrderBookOptions(_exchangeName, false, new[] { 1, 5 })
         {
             SupportsMultipleSymbols = true
         };
-        async Task<ExchangeResult<UpdateSubscription>> IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(SubscribeOrderBookRequest request, Action<DataEvent<SharedOrderBook>> handler, CancellationToken ct)
+        async Task<WebSocketResult<UpdateSubscription>> IOrderBookSocketClient.SubscribeToOrderBookUpdatesAsync(SubscribeOrderBookRequest request, Action<DataEvent<SharedOrderBook>> handler, CancellationToken ct)
         {
-            var validationError = ((IOrderBookSocketClient)this).SubscribeOrderBookOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeOrderBookOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var type = request.Limit == 1 ? OrderBookType.BBO_TBT : OrderBookType.OrderBook_5;
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)).ToArray() : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await ExchangeData.SubscribeToOrderBookUpdatesAsync(symbols, type, update => handler(update.ToType(new SharedOrderBook(update.Data.Asks, update.Data.Bids))), ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Balance client
-        EndpointOptions<SubscribeBalancesRequest> IBalanceSocketClient.SubscribeBalanceOptions { get; } = new EndpointOptions<SubscribeBalancesRequest>(false);
-        async Task<ExchangeResult<UpdateSubscription>> IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(SubscribeBalancesRequest request, Action<DataEvent<SharedBalance[]>> handler, CancellationToken ct)
+        SubscribeBalanceOptions IBalanceSocketClient.SubscribeBalanceOptions { get; } = new SubscribeBalanceOptions(_exchangeName, false);
+        async Task<WebSocketResult<UpdateSubscription>> IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(SubscribeBalancesRequest request, Action<DataEvent<SharedBalance[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IBalanceSocketClient)this).SubscribeBalanceOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeBalanceOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var result = await Account.SubscribeToAccountUpdatesAsync(null, false,
                 update =>
@@ -151,18 +149,18 @@ namespace OKX.Net.Clients.UnifiedApi
                 },
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Spot Order client
 
-        EndpointOptions<SubscribeSpotOrderRequest> ISpotOrderSocketClient.SubscribeSpotOrderOptions { get; } = new EndpointOptions<SubscribeSpotOrderRequest>(false);
-        async Task<ExchangeResult<UpdateSubscription>> ISpotOrderSocketClient.SubscribeToSpotOrderUpdatesAsync(SubscribeSpotOrderRequest request, Action<DataEvent<SharedSpotOrder[]>> handler, CancellationToken ct)
+        SubscribeSpotOrderOptions ISpotOrderSocketClient.SubscribeSpotOrderOptions { get; } = new SubscribeSpotOrderOptions(_exchangeName, false);
+        async Task<WebSocketResult<UpdateSubscription>> ISpotOrderSocketClient.SubscribeToSpotOrderUpdatesAsync(SubscribeSpotOrderRequest request, Action<DataEvent<SharedSpotOrder[]>> handler, CancellationToken ct)
         {
-            var validationError = ((ISpotOrderSocketClient)this).SubscribeSpotOrderOptions.ValidateRequest(Exchange, request, TradingMode.Spot, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeSpotOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
             var result = await Trading.SubscribeToOrderUpdatesAsync(InstrumentType.Spot, null, null,
                 update => handler(update.ToType<SharedSpotOrder[]>(new[] {
                     new SharedSpotOrder(
@@ -193,7 +191,7 @@ namespace OKX.Net.Clients.UnifiedApi
                 })),
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         private SharedOrderStatus ParseOrderStatus(OrderStatus orderState)
@@ -211,12 +209,12 @@ namespace OKX.Net.Clients.UnifiedApi
 
         #region Futures Order client
 
-        EndpointOptions<SubscribeFuturesOrderRequest> IFuturesOrderSocketClient.SubscribeFuturesOrderOptions { get; } = new EndpointOptions<SubscribeFuturesOrderRequest>(false);
-        async Task<ExchangeResult<UpdateSubscription>> IFuturesOrderSocketClient.SubscribeToFuturesOrderUpdatesAsync(SubscribeFuturesOrderRequest request, Action<DataEvent<SharedFuturesOrder[]>> handler, CancellationToken ct)
+        SubscribeFuturesOrderOptions IFuturesOrderSocketClient.SubscribeFuturesOrderOptions { get; } = new SubscribeFuturesOrderOptions(_exchangeName, false);
+        async Task<WebSocketResult<UpdateSubscription>> IFuturesOrderSocketClient.SubscribeToFuturesOrderUpdatesAsync(SubscribeFuturesOrderRequest request, Action<DataEvent<SharedFuturesOrder[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IFuturesOrderSocketClient)this).SubscribeFuturesOrderOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeFuturesOrderOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
             var result = await Trading.SubscribeToOrderUpdatesAsync(InstrumentType.Futures, null, null,
                 update => handler(update.ToType<SharedFuturesOrder[]>(new[] {
                     new SharedFuturesOrder(
@@ -251,7 +249,7 @@ namespace OKX.Net.Clients.UnifiedApi
                 })),
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         private decimal? ParseQuantity(OKXOrderUpdate data)
@@ -272,12 +270,12 @@ namespace OKX.Net.Clients.UnifiedApi
         #endregion
 
         #region User Trade client
-        EndpointOptions<SubscribeUserTradeRequest> IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new EndpointOptions<SubscribeUserTradeRequest>(false);
-        async Task<ExchangeResult<UpdateSubscription>> IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(SubscribeUserTradeRequest request, Action<DataEvent<SharedUserTrade[]>> handler, CancellationToken ct)
+        SubscribeUserTradeOptions IUserTradeSocketClient.SubscribeUserTradeOptions { get; } = new SubscribeUserTradeOptions(_exchangeName, false);
+        async Task<WebSocketResult<UpdateSubscription>> IUserTradeSocketClient.SubscribeToUserTradeUpdatesAsync(SubscribeUserTradeRequest request, Action<DataEvent<SharedUserTrade[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IUserTradeSocketClient)this).SubscribeUserTradeOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribeUserTradeOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var result = await Trading.SubscribeToUserTradeUpdatesAsync(
                 null,
@@ -297,17 +295,17 @@ namespace OKX.Net.Clients.UnifiedApi
                 })),
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
         #endregion
 
         #region Position client
-        EndpointOptions<SubscribePositionRequest> IPositionSocketClient.SubscribePositionOptions { get; } = new EndpointOptions<SubscribePositionRequest>(true);
-        async Task<ExchangeResult<UpdateSubscription>> IPositionSocketClient.SubscribeToPositionUpdatesAsync(SubscribePositionRequest request, Action<DataEvent<SharedPosition[]>> handler, CancellationToken ct)
+        SubscribePositionOptions IPositionSocketClient.SubscribePositionOptions { get; } = new SubscribePositionOptions(_exchangeName, true);
+        async Task<WebSocketResult<UpdateSubscription>> IPositionSocketClient.SubscribeToPositionUpdatesAsync(SubscribePositionRequest request, Action<DataEvent<SharedPosition[]>> handler, CancellationToken ct)
         {
-            var validationError = ((IPositionSocketClient)this).SubscribePositionOptions.ValidateRequest(Exchange, request, request.TradingMode, SupportedTradingModes);
+            var validationError = SharedClient.SubscribePositionOptions.ValidateRequest(request, this);
             if (validationError != null)
-                return new ExchangeResult<UpdateSubscription>(Exchange, validationError);
+                return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var instrType = request.TradingMode == null ? InstrumentType.Any : request.TradingMode.Value.IsPerpetual() ? InstrumentType.Swap : InstrumentType.Futures;
             var result = await Trading.SubscribeToPositionUpdatesAsync(
@@ -331,7 +329,7 @@ namespace OKX.Net.Clients.UnifiedApi
                 },
                 ct: ct).ConfigureAwait(false);
 
-            return new ExchangeResult<UpdateSubscription>(Exchange, result);
+            return result;
         }
 
         #endregion

--- a/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApiShared.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApiShared.cs
@@ -16,7 +16,7 @@ namespace OKX.Net.Clients.UnifiedApi
 
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
-        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(this);
+        public SharedClientInfo Discover() => SharedUtils.GetClientInfo(OKXExchange.Metadata, this);
 
         #region Ticker client
         SubscribeTickerOptions ITickerSocketClient.SubscribeTickerOptions { get; } = new SubscribeTickerOptions(_exchangeName) {
@@ -29,10 +29,18 @@ namespace OKX.Net.Clients.UnifiedApi
                 return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)).ToArray() : [request.Symbol!.GetSymbol(FormatSymbol)];
-            var result = await ExchangeData.SubscribeToTickerUpdatesAsync(symbols, update => handler(update.ToType(new SharedSpotTicker(ExchangeSymbolCache.ParseSymbol(request.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, update.Data.Symbol), update.Data.Symbol, update.Data.LastPrice ?? 0, update.Data.HighPrice ?? 0, update.Data.LowPrice ?? 0, update.Data.Volume, update.Data.OpenPrice == null ? null : Math.Round((update.Data.LastPrice ?? 0) / update.Data.OpenPrice.Value * 100 - 100, 2))
-            {
-                QuoteVolume = update.Data.QuoteVolume
-            })), ct: ct).ConfigureAwait(false);
+            var result = await ExchangeData.SubscribeToTickerUpdatesAsync(symbols, update => handler(update.ToType(
+                new SharedSpotTicker(
+                    ExchangeSymbolCache.ParseSymbol(request.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, EnvironmentName, null, update.Data.Symbol), 
+                    update.Data.Symbol,
+                    update.Data.LastPrice ?? 0,
+                    update.Data.HighPrice ?? 0,
+                    update.Data.LowPrice ?? 0,
+                    update.Data.Volume,
+                    update.Data.OpenPrice == null ? null : Math.Round((update.Data.LastPrice ?? 0) / update.Data.OpenPrice.Value * 100 - 100, 2))
+                {
+                    QuoteVolume = update.Data.QuoteVolume
+                })), ct: ct).ConfigureAwait(false);
 
             return result;
         }
@@ -49,7 +57,12 @@ namespace OKX.Net.Clients.UnifiedApi
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)).ToArray() : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await ExchangeData.SubscribeToTradeUpdatesAsync(symbols, update => handler(update.ToType<SharedTrade[]>(new[] {
-                new SharedTrade(ExchangeSymbolCache.ParseSymbol(request.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, update.Data.Symbol), update.Data.Symbol, update.Data.Quantity, update.Data.Price, update.Data.Time){
+                new SharedTrade(
+                    ExchangeSymbolCache.ParseSymbol(request.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, EnvironmentName, null, update.Data.Symbol),
+                    update.Data.Symbol,
+                    update.Data.Quantity,
+                    update.Data.Price,
+                    update.Data.Time){
                 Side = update.Data.Side == OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell
             } })), ct).ConfigureAwait(false);
 
@@ -71,7 +84,14 @@ namespace OKX.Net.Clients.UnifiedApi
                 return WebSocketResult.Fail<UpdateSubscription>(_exchangeName, validationError);
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)).ToArray() : [request.Symbol!.GetSymbol(FormatSymbol)];
-            var result = await ExchangeData.SubscribeToTickerUpdatesAsync(symbols, update => handler(update.ToType(new SharedBookTicker(ExchangeSymbolCache.ParseSymbol(request.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, update.Data.Symbol), update.Data.Symbol, update.Data.BestAskPrice ?? 0, update.Data.BestAskQuantity ?? 0, update.Data.BestBidPrice ?? 0, update.Data.BestBidQuantity ?? 0))), ct).ConfigureAwait(false);
+            var result = await ExchangeData.SubscribeToTickerUpdatesAsync(symbols, update => handler(update.ToType(
+                new SharedBookTicker(
+                    ExchangeSymbolCache.ParseSymbol(request.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, EnvironmentName, null, update.Data.Symbol),
+                    update.Data.Symbol,
+                    update.Data.BestAskPrice ?? 0,
+                    update.Data.BestAskQuantity ?? 0, 
+                    update.Data.BestBidPrice ?? 0,
+                    update.Data.BestBidQuantity ?? 0))), ct).ConfigureAwait(false);
 
             return result;
         }
@@ -105,7 +125,15 @@ namespace OKX.Net.Clients.UnifiedApi
 
             var symbols = request.Symbols?.Length > 0 ? request.Symbols.Select(x => x.GetSymbol(FormatSymbol)).ToArray() : [request.Symbol!.GetSymbol(FormatSymbol)];
             var result = await ExchangeData.SubscribeToKlineUpdatesAsync(symbols, interval, update => handler(update.ToType(
-                new SharedKline(ExchangeSymbolCache.ParseSymbol(request.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, update.Data.Symbol), update.Data.Symbol, update.Data.Time, update.Data.ClosePrice, update.Data.HighPrice, update.Data.LowPrice, update.Data.OpenPrice, update.Data.Volume))), ct).ConfigureAwait(false);
+                new SharedKline(
+                    ExchangeSymbolCache.ParseSymbol(request.TradingMode == TradingMode.Spot ? _topicSpotId : _topicFuturesId, EnvironmentName, null, update.Data.Symbol), 
+                    update.Data.Symbol,
+                    update.Data.Time,
+                    update.Data.ClosePrice,
+                    update.Data.HighPrice,
+                    update.Data.LowPrice,
+                    update.Data.OpenPrice, 
+                    update.Data.Volume))), ct).ConfigureAwait(false);
 
             return result;
         }
@@ -164,7 +192,7 @@ namespace OKX.Net.Clients.UnifiedApi
             var result = await Trading.SubscribeToOrderUpdatesAsync(InstrumentType.Spot, null, null,
                 update => handler(update.ToType<SharedSpotOrder[]>(new[] {
                     new SharedSpotOrder(
-                        ExchangeSymbolCache.ParseSymbol(_topicSpotId, update.Data.Symbol),
+                        ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null,update.Data.Symbol),
                         update.Data.Symbol,
                         update.Data.OrderId.ToString()!,
                         update.Data.OrderType == OrderType.Limit ? SharedOrderType.Limit : update.Data.OrderType == OrderType.Market ? SharedOrderType.Market : SharedOrderType.Other,
@@ -180,13 +208,22 @@ namespace OKX.Net.Clients.UnifiedApi
                         OrderPrice = update.Data.Price,
                         FeeAsset = update.Data.FeeAsset,
                         Fee = update.Data.Fee == null ? null : Math.Abs(update.Data.Fee.Value),
-                        LastTrade = update.Data.TradeId == null ? null : new SharedUserTrade(ExchangeSymbolCache.ParseSymbol(_topicSpotId, update.Data.Symbol), update.Data.Symbol, update.Data.OrderId.ToString()!, update.Data.TradeId.ToString()!, update.Data.OrderSide == OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell,  update.Data.QuantityFilled!.Value, update.Data.FillPrice!.Value, update.Data.FillTime!.Value)
-                        {
-                            ClientOrderId = update.Data.ClientOrderId,
-                            Fee = Math.Abs(update.Data.FillFee),
-                            FeeAsset = update.Data.FillFeeAsset,
-                            Role = update.Data.ExecutionType == "T" ? SharedRole.Taker : SharedRole.Maker
-                        }
+                        LastTrade = update.Data.TradeId == null ? null : 
+                        new SharedUserTrade(
+                            ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, update.Data.Symbol),
+                            update.Data.Symbol, 
+                            update.Data.OrderId.ToString()!,
+                            update.Data.TradeId.ToString()!,
+                            update.Data.OrderSide == OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell,
+                            update.Data.QuantityFilled!.Value, 
+                            update.Data.FillPrice!.Value,
+                            update.Data.FillTime!.Value)
+                            {
+                                ClientOrderId = update.Data.ClientOrderId,
+                                Fee = Math.Abs(update.Data.FillFee),
+                                FeeAsset = update.Data.FillFeeAsset,
+                                Role = update.Data.ExecutionType == "T" ? SharedRole.Taker : SharedRole.Maker
+                            }
                     }
                 })),
                 ct: ct).ConfigureAwait(false);
@@ -218,7 +255,7 @@ namespace OKX.Net.Clients.UnifiedApi
             var result = await Trading.SubscribeToOrderUpdatesAsync(InstrumentType.Futures, null, null,
                 update => handler(update.ToType<SharedFuturesOrder[]>(new[] {
                     new SharedFuturesOrder(
-                        ExchangeSymbolCache.ParseSymbol(_topicFuturesId, update.Data.Symbol),
+                        ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, update.Data.Symbol),
                         update.Data.Symbol,
                         update.Data.OrderId.ToString()!,
                         update.Data.OrderType == OrderType.Limit ? SharedOrderType.Limit : update.Data.OrderType == OrderType.Market ? SharedOrderType.Market : SharedOrderType.Other,
@@ -239,7 +276,16 @@ namespace OKX.Net.Clients.UnifiedApi
                         Fee = update.Data.Fee == null ? null : Math.Abs(update.Data.Fee.Value),
                         StopLossPrice = update.Data.StopLossTriggerPrice,
                         TakeProfitPrice = update.Data.TakeProfitTriggerPrice,
-                        LastTrade = update.Data.TradeId == null ? null : new SharedUserTrade(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, update.Data.Symbol), update.Data.Symbol, update.Data.OrderId.ToString()!, update.Data.TradeId.ToString()!, update.Data.OrderSide == OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell,  update.Data.QuantityFilled!.Value, update.Data.FillPrice!.Value, update.Data.FillTime!.Value)
+                        LastTrade = update.Data.TradeId == null ? null : 
+                        new SharedUserTrade(
+                            ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, update.Data.Symbol),
+                            update.Data.Symbol,
+                            update.Data.OrderId.ToString()!,
+                            update.Data.TradeId.ToString()!,
+                            update.Data.OrderSide == OrderSide.Buy ? SharedOrderSide.Buy : SharedOrderSide.Sell, 
+                            update.Data.QuantityFilled!.Value, 
+                            update.Data.FillPrice!.Value,
+                            update.Data.FillTime!.Value)
                         {
                             Fee = Math.Abs(update.Data.FillFee),
                             FeeAsset = update.Data.FillFeeAsset,
@@ -281,7 +327,7 @@ namespace OKX.Net.Clients.UnifiedApi
                 null,
                 update => handler(update.ToType<SharedUserTrade[]>(new[] {
                     new SharedUserTrade(
-                        ExchangeSymbolCache.ParseSymbol(_topicSpotId, update.Data.Symbol) ?? ExchangeSymbolCache.ParseSymbol(_topicFuturesId, update.Data.Symbol),
+                        ExchangeSymbolCache.ParseSymbol(_topicSpotId, EnvironmentName, null, update.Data.Symbol) ?? ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, update.Data.Symbol),
                         update.Data.Symbol,
                         update.Data.OrderId.ToString(),
                         update.Data.TradeId.ToString(),
@@ -318,7 +364,12 @@ namespace OKX.Net.Clients.UnifiedApi
                     if (update.UpdateType == SocketUpdateType.Snapshot)
                         return;
 
-                    handler(update.ToType<SharedPosition[]>(update.Data.Select(x => new SharedPosition(ExchangeSymbolCache.ParseSymbol(_topicFuturesId, x.Symbol), x.Symbol, x.PositionsQuantity ?? 0, x.UpdateTime)
+                    handler(update.ToType<SharedPosition[]>(update.Data.Select(x => 
+                    new SharedPosition(
+                        ExchangeSymbolCache.ParseSymbol(_topicFuturesId, EnvironmentName, null, x.Symbol), 
+                        x.Symbol, 
+                        x.PositionsQuantity ?? 0,
+                        x.UpdateTime)
                     {
                         AverageOpenPrice = x.AveragePrice,
                         PositionMode = x.PositionSide == PositionSide.Net ? SharedPositionMode.OneWay : SharedPositionMode.HedgeMode,

--- a/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApiShared.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApiShared.cs
@@ -173,7 +173,8 @@ namespace OKX.Net.Clients.UnifiedApi
                     if (update.UpdateType == SocketUpdateType.Snapshot)
                         return;
 
-                    handler(update.ToType<SharedBalance[]>(update.Data.Details.Select(x => new SharedBalance(x.Asset, x.AvailableBalance ?? 0, x.Equity ?? 0)).ToArray()));
+                    handler(update.ToType<SharedBalance[]>(update.Data.Details.Select(x => 
+                        new SharedBalance(SupportedTradingModes, x.Asset, x.AvailableBalance ?? 0, x.Equity ?? 0)).ToArray()));
                 },
                 ct: ct).ConfigureAwait(false);
 

--- a/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApiTrading.cs
+++ b/OKX.Net/Clients/UnifiedApi/OKXSocketClientUnifiedApiTrading.cs
@@ -26,7 +26,7 @@ internal class OKXSocketClientUnifiedApiTrading : IOKXSocketClientUnifiedApiTrad
     #endregion
 
     /// <inheritdoc />
-    public async Task<CallResult<OKXOrderPlaceResponse>> PlaceOrderAsync(
+    public async Task<QueryResult<OKXOrderPlaceResponse>> PlaceOrderAsync(
         long symbolCode,
         OrderSide side,
         OrderType type,
@@ -48,7 +48,7 @@ internal class OKXSocketClientUnifiedApiTrading : IOKXSocketClientUnifiedApiTrad
 
         CancellationToken ct = default)
     {
-        var parameters = new Dictionary<string, object>
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings)
         {
             { "tdMode", EnumConverter.GetString(tradeMode) },
             { "side", EnumConverter.GetString(side) },
@@ -57,77 +57,80 @@ internal class OKXSocketClientUnifiedApiTrading : IOKXSocketClientUnifiedApiTrad
         };
 
         parameters.AddParameter("instIdCode", symbolCode);
-        parameters.AddOptionalParameter("ccy", asset);
-        parameters.AddOptionalParameter("clOrdId", clientOrderId);
-        parameters.AddOptionalParameter("tag", LibraryHelpers.GetClientReference(() => _client.ClientOptions.BrokerId, _client.Exchange));
-        parameters.AddOptionalParameter("posSide", EnumConverter.GetString(positionSide));
-        parameters.AddOptionalParameter("px", price?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("reduceOnly", reduceOnly);
-        parameters.AddOptionalParameter("tgtCcy", EnumConverter.GetString(quantityAsset));
-        parameters.AddOptionalParameter("quickMgnType", EnumConverter.GetString(quickMarginType));
-        parameters.AddOptionalParameter("stpId", selfTradePreventionId);
-        parameters.AddOptionalParameter("stpMode", EnumConverter.GetString(selfTradePreventionMode));
-        parameters.AddOptionalParameter("tradeQuoteCcy", tradeQuoteAsset);
-        parameters.AddOptionalParameter("slippagePct", maxSlippagePercentage?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("ccy", asset);
+        parameters.Add("clOrdId", clientOrderId);
+        parameters.Add("tag", LibraryHelpers.GetClientReference(() => _client.ClientOptions.BrokerId, _client.Exchange));
+        parameters.Add("posSide", EnumConverter.GetString(positionSide));
+        parameters.Add("px", price?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("reduceOnly", reduceOnly);
+        parameters.Add("tgtCcy", EnumConverter.GetString(quantityAsset));
+        parameters.Add("quickMgnType", EnumConverter.GetString(quickMarginType));
+        parameters.Add("stpId", selfTradePreventionId);
+        parameters.Add("stpMode", EnumConverter.GetString(selfTradePreventionMode));
+        parameters.Add("tradeQuoteCcy", tradeQuoteAsset);
+        parameters.Add("slippagePct", maxSlippagePercentage?.ToString(CultureInfo.InvariantCulture));
 
         var result = await _client.QueryInternalAsync<OKXOrderPlaceResponse>(_client.GetUri("/ws/v5/private"), "order", parameters, true, 1, ct).ConfigureAwait(false);
-        if (!result)
+        if (!result.Success)
             return result;
 
         if (!result.Data.Success)
-            return result.AsError<OKXOrderPlaceResponse>(new ServerError(result.Data.Code, _client.GetErrorInfo(result.Data.Code, result.Data.Message)));
+            return QueryResult.Fail<OKXOrderPlaceResponse>(result, new ServerError(result.Data.Code, _client.GetErrorInfo(result.Data.Code, result.Data.Message)));
 
         return result;
     }
 
     /// <inheritdoc />
-    public async Task<CallResult<CallResult<OKXOrderPlaceResponse>[]>> PlaceMultipleOrdersAsync(IEnumerable<OKXOrderPlaceRequest> orders, CancellationToken ct = default)
+    public async Task<QueryResult<CallResult<OKXOrderPlaceResponse>[]>> PlaceMultipleOrdersAsync(IEnumerable<OKXOrderPlaceRequest> orders, CancellationToken ct = default)
     {
         foreach (var order in orders)
             order.Tag = LibraryHelpers.GetClientReference(() => _client.ClientOptions.BrokerId, _client.Exchange);        
 
         var result = await _client.QueryInternalAsync<OKXOrderPlaceResponse>(_client.GetUri("/ws/v5/private"), "batch-orders", orders.ToArray(), true, 1, ct).ConfigureAwait(false);
+        if (!result.Success)
+            return QueryResult.Fail<CallResult<OKXOrderPlaceResponse>[]>(result);
+
         var ordersResult = new List<CallResult<OKXOrderPlaceResponse>>();
         foreach (var item in result.Data)
         {
             if (item.Code > 0)
-                ordersResult.Add(new CallResult<OKXOrderPlaceResponse>(item, null, new ServerError(item.Code, _client.GetErrorInfo(item.Code, item.Message!))));
+                ordersResult.Add(CallResult.Fail<OKXOrderPlaceResponse>(new ServerError(item.Code, _client.GetErrorInfo(item.Code, item.Message!))));
             else
-                ordersResult.Add(new CallResult<OKXOrderPlaceResponse>(item));
+                ordersResult.Add(CallResult.Ok(item));
         }
 
         if (ordersResult.All(x => !x.Success))
-            return result.AsErrorWithData(new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All errors failed")), ordersResult.ToArray());
+            return QueryResult.Fail(result, new ServerError(new ErrorInfo(ErrorType.AllOrdersFailed, "All errors failed")), ordersResult.ToArray());
 
-        return result.As(ordersResult.ToArray());
+        return QueryResult.Ok(result, ordersResult.ToArray());
     }
 
     /// <inheritdoc />
-    public async Task<CallResult<OKXOrderCancelResponse>> CancelOrderAsync(long symbolCode, string? orderId = null, string? clientOrderId = null, CancellationToken ct = default)
+    public async Task<QueryResult<OKXOrderCancelResponse>> CancelOrderAsync(long symbolCode, string? orderId = null, string? clientOrderId = null, CancellationToken ct = default)
     {
-        var parameters = new Dictionary<string, object>();
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
         parameters.AddParameter("instIdCode", symbolCode);
-        parameters.AddOptionalParameter("ordId", orderId);
-        parameters.AddOptionalParameter("clOrdId", clientOrderId);
+        parameters.Add("ordId", orderId);
+        parameters.Add("clOrdId", clientOrderId);
 
         var result = await _client.QueryInternalAsync<OKXOrderCancelResponse>(_client.GetUri("/ws/v5/private"), "cancel-order", parameters, true, 1, ct).ConfigureAwait(false);
-        if (!result)
+        if (!result.Success)
             return result;
 
         if (!result.Data.Success)
-            return result.AsError<OKXOrderCancelResponse>(new ServerError(result.Data.Code, _client.GetErrorInfo(result.Data.Code, result.Data.Message)));
+            return QueryResult.Fail<OKXOrderCancelResponse>(result, new ServerError(result.Data.Code, _client.GetErrorInfo(result.Data.Code, result.Data.Message)));
 
         return result;
     }
 
     /// <inheritdoc />
-    public async Task<CallResult<OKXOrderCancelResponse[]>> CancelMultipleOrdersAsync(IEnumerable<OKXOrderCancelSocketRequest> ordersToCancel, CancellationToken ct = default)
+    public async Task<QueryResult<OKXOrderCancelResponse[]>> CancelMultipleOrdersAsync(IEnumerable<OKXOrderCancelSocketRequest> ordersToCancel, CancellationToken ct = default)
     {
         return await _client.QueryInternalAsync<OKXOrderCancelResponse>(_client.GetUri("/ws/v5/private"), "batch-cancel-orders", ordersToCancel, true, 1, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<OKXOrderAmendResponse>> AmendOrderAsync(
+    public virtual async Task<QueryResult<OKXOrderAmendResponse>> AmendOrderAsync(
         long symbolCode,
         long? orderId = null,
         string? clientOrderId = null,
@@ -136,32 +139,32 @@ internal class OKXSocketClientUnifiedApiTrading : IOKXSocketClientUnifiedApiTrad
         decimal? newPrice = null,
         CancellationToken ct = default)
     {
-        var parameters = new Dictionary<string, object>();
+        var parameters = new Parameters(OKXExchange._parameterSerializationSettings);
         parameters.AddParameter("instIdCode", symbolCode);
-        parameters.AddOptionalParameter("ordId", orderId?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("clOrdId", clientOrderId);
-        parameters.AddOptionalParameter("reqId", requestId);
-        parameters.AddOptionalParameter("newSz", newQuantity?.ToString(CultureInfo.InvariantCulture));
-        parameters.AddOptionalParameter("newPx", newPrice?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("ordId", orderId?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("clOrdId", clientOrderId);
+        parameters.Add("reqId", requestId);
+        parameters.Add("newSz", newQuantity?.ToString(CultureInfo.InvariantCulture));
+        parameters.Add("newPx", newPrice?.ToString(CultureInfo.InvariantCulture));
 
         var result = await _client.QueryInternalAsync<OKXOrderAmendResponse>(_client.GetUri("/ws/v5/private"), "amend-order", parameters, true, 1, ct).ConfigureAwait(false);
-        if (!result)
+        if (!result.Success)
             return result;
 
         if (!result.Data.Success)
-            return result.AsError<OKXOrderAmendResponse>(new ServerError(result.Data.Code, _client.GetErrorInfo(result.Data.Code, result.Data.Message)));
+            return QueryResult.Fail<OKXOrderAmendResponse>(result, new ServerError(result.Data.Code, _client.GetErrorInfo(result.Data.Code, result.Data.Message)));
 
         return result;
     }
 
     /// <inheritdoc />
-    public async Task<CallResult<OKXOrderAmendResponse[]>> AmendMultipleOrdersAsync(IEnumerable<OKXOrderAmendRequest> ordersToCancel, CancellationToken ct = default)
+    public async Task<QueryResult<OKXOrderAmendResponse[]>> AmendMultipleOrdersAsync(IEnumerable<OKXOrderAmendRequest> ordersToCancel, CancellationToken ct = default)
     {
         return await _client.QueryInternalAsync<OKXOrderAmendResponse>(_client.GetUri("/ws/v5/private"), "batch-amend-orders", ordersToCancel, true, 1, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(
         InstrumentType instrumentType,
         string? symbol,
         string? instrumentFamily,
@@ -200,7 +203,7 @@ internal class OKXSocketClientUnifiedApiTrading : IOKXSocketClientUnifiedApiTrad
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToLiquidationWarningUpdatesAsync(InstrumentType instrumentType,
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToLiquidationWarningUpdatesAsync(InstrumentType instrumentType,
         string? instrumentFamily,
         Action<DataEvent<OKXPosition>> onData,
         CancellationToken ct = default)
@@ -233,7 +236,7 @@ internal class OKXSocketClientUnifiedApiTrading : IOKXSocketClientUnifiedApiTrad
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(
         InstrumentType instrumentType,
         string? symbol,
         string? instrumentFamily,
@@ -269,7 +272,7 @@ internal class OKXSocketClientUnifiedApiTrading : IOKXSocketClientUnifiedApiTrad
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(
         string? symbol,
         Action<DataEvent<OKXUserTradeUpdate>> onData,
         CancellationToken ct = default)
@@ -301,7 +304,7 @@ internal class OKXSocketClientUnifiedApiTrading : IOKXSocketClientUnifiedApiTrad
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToAlgoOrderUpdatesAsync(
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToAlgoOrderUpdatesAsync(
         InstrumentType instrumentType,
         string? symbol,
         string? instrumentFamily,
@@ -338,7 +341,7 @@ internal class OKXSocketClientUnifiedApiTrading : IOKXSocketClientUnifiedApiTrad
     }
 
     /// <inheritdoc />
-    public virtual async Task<CallResult<UpdateSubscription>> SubscribeToAdvanceAlgoOrderUpdatesAsync(
+    public virtual async Task<WebSocketResult<UpdateSubscription>> SubscribeToAdvanceAlgoOrderUpdatesAsync(
         InstrumentType instrumentType,
         string? symbol,
         string? algoId,

--- a/OKX.Net/Converters/OKXSourceGenerationContext.cs
+++ b/OKX.Net/Converters/OKXSourceGenerationContext.cs
@@ -228,6 +228,8 @@ namespace OKX.Net.Converters
     [JsonSerializable(typeof(decimal))]
     [JsonSerializable(typeof(DateTime))]
     [JsonSerializable(typeof(DateTime?))]
+    [JsonSerializable(typeof(Parameters))]
+    [JsonSerializable(typeof(Parameters[]))]
     internal partial class OKXSourceGenerationContext : JsonSerializerContext
     {
     }

--- a/OKX.Net/ExtensionMethods/ServiceCollectionExtensions.cs
+++ b/OKX.Net/ExtensionMethods/ServiceCollectionExtensions.cs
@@ -47,8 +47,10 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var restEnvName = options.Rest.Environment?.Name ?? options.Environment?.Name ?? OKXEnvironment.Live.Name;
             var socketEnvName = options.Socket.Environment?.Name ?? options.Environment?.Name ?? OKXEnvironment.Live.Name;
+            options.Rest.SharedApiEuropeUseXPerps = options.Rest.SharedApiEuropeUseXPerps || options.SharedApiEuropeUseXPerps;
             options.Rest.Environment = OKXEnvironment.GetEnvironmentByName(restEnvName) ?? options.Rest.Environment!;
             options.Rest.ApiCredentials = options.Rest.ApiCredentials ?? options.ApiCredentials;
+            options.Socket.SharedApiEuropeUseXPerps = options.Socket.SharedApiEuropeUseXPerps || options.SharedApiEuropeUseXPerps;
             options.Socket.Environment = OKXEnvironment.GetEnvironmentByName(socketEnvName) ?? options.Socket.Environment!;
             options.Socket.ApiCredentials = options.Socket.ApiCredentials ?? options.ApiCredentials;
 
@@ -76,8 +78,10 @@ namespace Microsoft.Extensions.DependencyInjection
             if (options.Rest == null || options.Socket == null)
                 throw new ArgumentException("Options null");
 
+            options.Rest.SharedApiEuropeUseXPerps = options.Rest.SharedApiEuropeUseXPerps || options.SharedApiEuropeUseXPerps;
             options.Rest.Environment = options.Rest.Environment ?? options.Environment ?? OKXEnvironment.Live;
             options.Rest.ApiCredentials = options.Rest.ApiCredentials ?? options.ApiCredentials;
+            options.Socket.SharedApiEuropeUseXPerps = options.Socket.SharedApiEuropeUseXPerps || options.SharedApiEuropeUseXPerps;
             options.Socket.Environment = options.Socket.Environment ?? options.Environment ?? OKXEnvironment.Live;
             options.Socket.ApiCredentials = options.Socket.ApiCredentials ?? options.ApiCredentials;
 

--- a/OKX.Net/Interfaces/Clients/IOKXUserClientProvider.cs
+++ b/OKX.Net/Interfaces/Clients/IOKXUserClientProvider.cs
@@ -19,6 +19,11 @@
         public void ClearUserClients(string userIdentifier);
 
         /// <summary>
+        /// Clear all client from the cache
+        /// </summary>
+        void Clear();
+
+        /// <summary>
         /// Get the Rest client for a specific user. In case the client does not exist yet it will be created and the <paramref name="credentials"/> should be provided, unless <see cref="InitializeUserClient" /> has been called prior for this user.
         /// </summary>
         /// <param name="userIdentifier">The identifier for user</param>

--- a/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXRestClientUnifiedApiAccount.cs
+++ b/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXRestClientUnifiedApiAccount.cs
@@ -23,7 +23,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="withdrawalId">["<c>wdId</c>"] Withdrawal ID</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXWithdrawalId>> CancelWithdrawalAsync(string withdrawalId, CancellationToken ct = default);
+    Task<HttpResult<OKXWithdrawalId>> CancelWithdrawalAsync(string withdrawalId, CancellationToken ct = default);
 
     /// <summary>
     /// Get a list of assets (with non-zero balance), remaining balance, and available amount in the account.
@@ -37,7 +37,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="asset">["<c>ccy</c>"] Asset, for example `ETH`</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAccountBalance>> GetAccountBalanceAsync(string? asset = null, CancellationToken ct = default);
+    Task<HttpResult<OKXAccountBalance>> GetAccountBalanceAsync(string? asset = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get current account configuration.
@@ -50,7 +50,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// </summary>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAccountConfiguration>> GetAccountConfigurationAsync(CancellationToken ct = default);
+    Task<HttpResult<OKXAccountConfiguration>> GetAccountConfigurationAsync(CancellationToken ct = default);
 
     /// <summary>
     /// Get Leverage
@@ -66,7 +66,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="asset">["<c>ccy</c>"] Asset, only applicable to Quick Margin Mode</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXLeverage[]>> GetLeverageAsync(string symbols, MarginMode marginMode, string? asset = null, CancellationToken ct = default);
+    Task<HttpResult<OKXLeverage[]>> GetLeverageAsync(string symbols, MarginMode marginMode, string? asset = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get estimated leverage info
@@ -84,7 +84,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="asset">["<c>ccy</c>"] Asset</param>
     /// <param name="positionSide">["<c>posSide</c>"] Position side</param>
     /// <param name="ct">Cancellation Token</param>
-    Task<WebCallResult<OKXEstimatedLeverageInfo[]>> GetEstimatedLeverageInfoAsync(InstrumentType instrumentType, MarginMode marginMode, int leverage, string? symbol = null, string? asset = null, PositionSide? positionSide = null, CancellationToken ct = default);
+    Task<HttpResult<OKXEstimatedLeverageInfo[]>> GetEstimatedLeverageInfoAsync(InstrumentType instrumentType, MarginMode marginMode, int leverage, string? symbol = null, string? asset = null, PositionSide? positionSide = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get the updated position data for the last 3 months. Return in reverse chronological order using utime.
@@ -105,7 +105,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="limit">["<c>limit</c>"] Number of results per request. The maximum is 100. The default is 100.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXClosingPosition[]>> GetPositionHistoryAsync(InstrumentType? instrumentType = null, string? symbol = null, MarginMode? marginMode = null, ClosingPositionType? type = null, string? positionId = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, CancellationToken ct = default);
+    Task<HttpResult<OKXClosingPosition[]>> GetPositionHistoryAsync(InstrumentType? instrumentType = null, string? symbol = null, MarginMode? marginMode = null, ClosingPositionType? type = null, string? positionId = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, CancellationToken ct = default);
 
     /// <summary>
     /// Get account and position risk
@@ -119,7 +119,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="instrumentType">["<c>instType</c>"] Instrument Type</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXPositionRisk[]>> GetPositionRiskAsync(InstrumentType? instrumentType = null, CancellationToken ct = default);
+    Task<HttpResult<OKXPositionRisk[]>> GetPositionRiskAsync(InstrumentType? instrumentType = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get account risk state
@@ -131,7 +131,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// </para>
     /// </summary>
     /// <param name="ct">Cancellation Token</param>
-    Task<WebCallResult<OKXRiskState[]>> GetAccountRiskStateAsync(CancellationToken ct = default);
+    Task<HttpResult<OKXRiskState[]>> GetAccountRiskStateAsync(CancellationToken ct = default);
 
     /// <summary>
     /// Get position info. When the account is in net mode, net positions will be displayed, and when the account is in long/short mode, long or short positions will be displayed.
@@ -147,7 +147,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="positionId">["<c>posId</c>"] Position ID</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXPosition[]>> GetPositionsAsync(InstrumentType? instrumentType = null, string? symbol = null, string? positionId = null, CancellationToken ct = default);
+    Task<HttpResult<OKXPosition[]>> GetPositionsAsync(InstrumentType? instrumentType = null, string? symbol = null, string? positionId = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get the account’s bills. The bill refers to all transaction records that result in changing the balance of an account. Pagination is supported, and the response is sorted with most recent first. This endpoint can retrieve data from the last 3 months.
@@ -171,7 +171,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="toId">["<c>before</c>"] Pagination of data to return records newer than the requested id</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAccountBill[]>> GetBillArchiveAsync(InstrumentType? instrumentType = null, string? asset = null, MarginMode? marginMode = null, ContractType? contractType = null, AccountBillType? billType = null, AccountBillSubType? billSubType = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, string? fromId = null, string? toId = null, CancellationToken ct = default);
+    Task<HttpResult<OKXAccountBill[]>> GetBillArchiveAsync(InstrumentType? instrumentType = null, string? asset = null, MarginMode? marginMode = null, ContractType? contractType = null, AccountBillType? billType = null, AccountBillSubType? billSubType = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, string? fromId = null, string? toId = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get the bills of the account. The bill refers to all transaction records that result in changing the balance of an account. Pagination is supported, and the response is sorted with the most recent first. This endpoint can retrieve data from the last 7 days.
@@ -195,7 +195,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="toId">["<c>before</c>"] Pagination of data to return records newer than the requested id</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAccountBill[]>> GetBillHistoryAsync(InstrumentType? instrumentType = null, string? asset = null, MarginMode? marginMode = null, ContractType? contractType = null, AccountBillType? billType = null, AccountBillSubType? billSubType = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, string? fromId = null, string? toId = null, CancellationToken ct = default);
+    Task<HttpResult<OKXAccountBill[]>> GetBillHistoryAsync(InstrumentType? instrumentType = null, string? asset = null, MarginMode? marginMode = null, ContractType? contractType = null, AccountBillType? billType = null, AccountBillSubType? billSubType = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, string? fromId = null, string? toId = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get a list of all assets. Not all assets can be traded. Assets that have not been defined in ISO 4217 may use a custom symbol.
@@ -209,7 +209,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="asset">["<c>ccy</c>"] Single asset or multiple assets (no more than 20) separated with comma, for example `ETH`</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAsset[]>> GetAssetsAsync(string? asset = null, CancellationToken ct = default);
+    Task<HttpResult<OKXAsset[]>> GetAssetsAsync(string? asset = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get the deposit addresses of assets, including previously-used addresses.
@@ -223,7 +223,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="asset">["<c>ccy</c>"] Asset, for example `ETH`</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXDepositAddress[]>> GetDepositAddressAsync(string? asset = null, CancellationToken ct = default);
+    Task<HttpResult<OKXDepositAddress[]>> GetDepositAddressAsync(string? asset = null, CancellationToken ct = default);
 
     /// <summary>
     /// Retrieve the deposit history of all assets, up to 100 recent records in a year.
@@ -245,7 +245,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="type">["<c>type</c>"] Deposit Type</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXDepositHistory[]>> GetDepositHistoryAsync(string? asset = null, string? transactionId = null, DepositState? state = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, string? depositId = null, string? fromWithdrawalId = null, DepositType? type = null, CancellationToken ct = default);
+    Task<HttpResult<OKXDepositHistory[]>> GetDepositHistoryAsync(string? asset = null, string? transactionId = null, DepositState? state = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, string? depositId = null, string? fromWithdrawalId = null, DepositType? type = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get Fee Rates
@@ -264,7 +264,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="groupId">["<c>groupId</c>"] Instrument trading fee group id</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXFeeRate>> GetFeeRatesAsync(
+    Task<HttpResult<OKXFeeRate>> GetFeeRatesAsync(
         InstrumentType instrumentType,
         string? symbol = null,
         string? underlying = null,
@@ -285,7 +285,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="asset">["<c>ccy</c>"] Asset, for example `ETH`</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXFundingBalance[]>> GetFundingBalanceAsync(string? asset = null, CancellationToken ct = default);
+    Task<HttpResult<OKXFundingBalance[]>> GetFundingBalanceAsync(string? asset = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get billing records, you can get the latest 1 month historical data
@@ -306,7 +306,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="clientId">["<c>clientId</c>"] Client id</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXFundingBill[]>> GetFundingBillDetailsAsync(string? asset = null, FundingBillType? type = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, string? clientId = null, long? startBillId = null, long? endBillId = null, CancellationToken ct = default);
+    Task<HttpResult<OKXFundingBill[]>> GetFundingBillDetailsAsync(string? asset = null, FundingBillType? type = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, string? clientId = null, long? startBillId = null, long? endBillId = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get historical asset billing records (longer lookback than asset bills details)
@@ -327,7 +327,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="clientId">["<c>clientId</c>"] Client id</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXFundingBill[]>> GetFundingBillHistoryAsync(string? asset = null, FundingBillType? type = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, string? clientId = null, long? startBillId = null, long? endBillId = null, CancellationToken ct = default);
+    Task<HttpResult<OKXFundingBill[]>> GetFundingBillHistoryAsync(string? asset = null, FundingBillType? type = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, string? clientId = null, long? startBillId = null, long? endBillId = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get interest-accrued
@@ -346,7 +346,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="limit">["<c>limit</c>"] Number of results per request. The maximum is 100; the default is 100.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXInterestAccrued[]>> GetInterestAccruedAsync(string? symbol = null, string? asset = null, MarginMode? marginMode = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, CancellationToken ct = default);
+    Task<HttpResult<OKXInterestAccrued[]>> GetInterestAccruedAsync(string? symbol = null, string? asset = null, MarginMode? marginMode = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, CancellationToken ct = default);
 
     /// <summary>
     /// Get the user's current leveraged currency borrowing interest rate
@@ -360,7 +360,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="asset">["<c>ccy</c>"] Asset, for example `ETH`</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAccountInterestRate[]>> GetInterestRateAsync(string? asset = null, CancellationToken ct = default);
+    Task<HttpResult<OKXAccountInterestRate[]>> GetInterestRateAsync(string? asset = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get borrow interest and limit
@@ -374,7 +374,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="type">["<c>type</c>"] Type of loan</param>
     /// <param name="asset">["<c>ccy</c>"] Asset</param>
     /// <param name="ct">Cancellation Token</param>
-    Task<WebCallResult<OKXBorrowInterestLimit[]>> GetBorrowInterestLimitAsync(LoanType? type = null, string? asset = null, CancellationToken ct = default);
+    Task<HttpResult<OKXBorrowInterestLimit[]>> GetBorrowInterestLimitAsync(LoanType? type = null, string? asset = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get maximum buy/sell amount or open amount
@@ -393,7 +393,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="tradeQuoteAsset">["<c>tradeQuoteCcy</c>"] The quote currency used for trading. Only applicable to SPOT. The default value is the quote currency of the symbol, for example: for BTC-USD, the default is USD.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXMaximumAmount[]>> GetMaximumAmountAsync(
+    Task<HttpResult<OKXMaximumAmount[]>> GetMaximumAmountAsync(
         string symbol,
         TradeMode tradeMode,
         string? asset = null,
@@ -418,7 +418,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="tradeQuoteAsset">["<c>tradeQuoteCcy</c>"] The quote currency used for trading. Only applicable to SPOT. The default value is the quote currency of the symbol, for example: for BTC-USD, the default is USD.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXMaximumAvailableAmount[]>> GetMaximumAvailableAmountAsync(
+    Task<HttpResult<OKXMaximumAvailableAmount[]>> GetMaximumAvailableAmountAsync(
         string symbol,
         TradeMode tradeMode,
         string? asset = null,
@@ -441,7 +441,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="marginAsset">["<c>mgnCcy</c>"] Margin asset</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXMaximumLoanAmount[]>> GetMaximumLoanAmountAsync(MarginMode marginMode, string? symbol = null, string? asset = null, string? marginAsset = null, CancellationToken ct = default);
+    Task<HttpResult<OKXMaximumLoanAmount[]>> GetMaximumLoanAmountAsync(MarginMode marginMode, string? symbol = null, string? asset = null, string? marginAsset = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get the maximum transferable amount.
@@ -455,7 +455,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="asset">["<c>ccy</c>"] Asset, for example 'ETH'</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXWithdrawalAmount[]>> GetMaximumWithdrawalsAsync(string? asset = null, CancellationToken ct = default);
+    Task<HttpResult<OKXWithdrawalAmount[]>> GetMaximumWithdrawalsAsync(string? asset = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get saving balances. Only the assets in the funding account can be used for saving.
@@ -469,7 +469,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="asset">["<c>ccy</c>"] Asset, for example 'ETH'</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXSavingBalance[]>> GetSavingBalancesAsync(string? asset = null, CancellationToken ct = default);
+    Task<HttpResult<OKXSavingBalance[]>> GetSavingBalancesAsync(string? asset = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get the withdrawal records according to the currency, withdrawal status, and time range in reverse chronological order. The 100 most recent records are returned by default.
@@ -490,7 +490,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="clientId">["<c>clientId</c>"] Client id</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXWithdrawalHistory[]>> GetWithdrawalHistoryAsync(string? asset = null, string? transactionId = null, WithdrawalState? state = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, string? withdrawalId = null, string? clientId = null, CancellationToken ct = default);
+    Task<HttpResult<OKXWithdrawalHistory[]>> GetWithdrawalHistoryAsync(string? asset = null, string? transactionId = null, WithdrawalState? state = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, string? withdrawalId = null, string? clientId = null, CancellationToken ct = default);
 
     /// <summary>
     /// Purchase or redeem saving shares
@@ -507,7 +507,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="rate">["<c>rate</c>"] Rate</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXSavingActionResponse>> SavingPurchaseRedemptionAsync(string asset, decimal amount, SavingActionSide side, decimal? rate = null, CancellationToken ct = default);
+    Task<HttpResult<OKXSavingActionResponse>> SavingPurchaseRedemptionAsync(string asset, decimal amount, SavingActionSide side, decimal? rate = null, CancellationToken ct = default);
 
     /// <summary>
     /// Set leverage. The following are the setting leverage cases for an instrument:<br />
@@ -529,7 +529,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="positionSide">["<c>posSide</c>"] Position Side</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXLeverage[]>> SetLeverageAsync(int leverage, MarginMode marginMode, string? asset = null, string? symbol = null, PositionSide? positionSide = null, CancellationToken ct = default);
+    Task<HttpResult<OKXLeverage[]>> SetLeverageAsync(int leverage, MarginMode marginMode, string? asset = null, string? symbol = null, PositionSide? positionSide = null, CancellationToken ct = default);
 
     /// <summary>
     /// Set position mode. FUTURES and SWAP support both long/short mode and net mode. In net mode, users can only have positions in one direction; In long/short mode, users can hold positions in long and short directions.
@@ -543,7 +543,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="positionMode">["<c>posMode</c>"] Position mode</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAccountPositionMode>> SetPositionModeAsync(PositionMode positionMode, CancellationToken ct = default);
+    Task<HttpResult<OKXAccountPositionMode>> SetPositionModeAsync(PositionMode positionMode, CancellationToken ct = default);
 
     /// <summary>
     /// Set the display type of Greeks.
@@ -557,7 +557,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="greeksType">["<c>greeksType</c>"] Display type of Greeks.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAccountGreeksType>> SetGreeksAsync(GreeksType greeksType, CancellationToken ct = default);
+    Task<HttpResult<OKXAccountGreeksType>> SetGreeksAsync(GreeksType greeksType, CancellationToken ct = default);
 
     /// <summary>
     /// Increase or decrease the margin of the isolated position.
@@ -576,7 +576,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="auto">["<c>auto</c>"] Automatic loan transfer out</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXMarginAmount[]>> SetMarginAmountAsync(string symbol, PositionSide positionSide, MarginAddReduce marginAddReduce, decimal amount, string? asset = null, bool? auto = null, CancellationToken ct = default);
+    Task<HttpResult<OKXMarginAmount[]>> SetMarginAmountAsync(string symbol, PositionSide positionSide, MarginAddReduce marginAddReduce, decimal amount, string? asset = null, bool? auto = null, CancellationToken ct = default);
 
     /// <summary>
     /// Transfer asset. This endpoint supports the transfer of funds between your funding account and trading account, and from the master account to sub-accounts. Direct transfers between sub-accounts are not allowed.
@@ -600,7 +600,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="ignorePositionRisk">Ignore position risk</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXTransferResponse>> TransferAsync(string asset, decimal amount, TransferType type, AccountType fromAccount, AccountType toAccount, string? subAccountName = null, string? fromSymbol = null, string? toSymbol = null, bool? loanTransfer = null, string? clientId = null, bool? ignorePositionRisk = null, CancellationToken ct = default);
+    Task<HttpResult<OKXTransferResponse>> TransferAsync(string asset, decimal amount, TransferType type, AccountType fromAccount, AccountType toAccount, string? subAccountName = null, string? fromSymbol = null, string? toSymbol = null, bool? loanTransfer = null, string? clientId = null, bool? ignorePositionRisk = null, CancellationToken ct = default);
 
     /// <summary>
     /// Withdraw an asset
@@ -621,7 +621,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="clientId">["<c>clientId</c>"] Client-supplied ID</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXWithdrawalResponse>> WithdrawAsync(string asset, decimal amount, WithdrawalDestination destination, string toAddress, decimal fee, string? network = null, string? areaCode = null, string? clientId = null, CancellationToken ct = default);
+    Task<HttpResult<OKXWithdrawalResponse>> WithdrawAsync(string asset, decimal amount, WithdrawalDestination destination, string toAddress, decimal fee, string? network = null, string? areaCode = null, string? clientId = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get assets available for dust conversion
@@ -634,7 +634,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// </summary>
     /// <param name="sourceAccount">["<c>source</c>"] Source account type</param>
     /// <param name="ct">Cancellation token</param>
-    Task<WebCallResult<OKXDustAssets>> GetEasyConvertDustAssetsAsync(AccountType? sourceAccount = null, CancellationToken ct = default);
+    Task<HttpResult<OKXDustAssets>> GetEasyConvertDustAssetsAsync(AccountType? sourceAccount = null, CancellationToken ct = default);
 
     /// <summary>
     /// Convert small assets in funding account to a target asset
@@ -650,7 +650,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="sourceAccount">["<c>source</c>"] Convert from account</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXDustConvertEntry[]>> EasyConvertDustAsync(IEnumerable<string> assets, string targetAsset, AccountType? sourceAccount = null, CancellationToken ct = default);
+    Task<HttpResult<OKXDustConvertEntry[]>> EasyConvertDustAsync(IEnumerable<string> assets, string targetAsset, AccountType? sourceAccount = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get easy dust convert history
@@ -665,7 +665,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="endTime">["<c>before</c>"] Filter by end time</param>
     /// <param name="limit">["<c>limit</c>"] Max number of results</param>
     /// <param name="ct">Cancellation token</param>
-    Task<WebCallResult<OKXDustConvertEntry[]>> GetEasyConvertDustHistoryAsync(DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default);
+    Task<HttpResult<OKXDustConvertEntry[]>> GetEasyConvertDustHistoryAsync(DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default);
 
     /// <summary>
     /// Set isolated margin mode for the Margin or Contracts instrument type
@@ -680,7 +680,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="isolatedMarginMode">["<c>isoMode</c>"] Isolated margin mode</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAccountIsolatedMarginMode>> SetIsolatedMarginModeAsync(InstrumentType instumentType, IsolatedMarginMode isolatedMarginMode, CancellationToken ct = default);
+    Task<HttpResult<OKXAccountIsolatedMarginMode>> SetIsolatedMarginModeAsync(InstrumentType instumentType, IsolatedMarginMode isolatedMarginMode, CancellationToken ct = default);
 
     /// <summary>
     /// Get info on a transfer
@@ -696,7 +696,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="type">["<c>type</c>"] The type of transfer</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXTransferInfo>> GetTransferAsync(string? transferId = null, string? clientTransferId = null, TransferType? type = null, CancellationToken ct = default);
+    Task<HttpResult<OKXTransferInfo>> GetTransferAsync(string? transferId = null, string? clientTransferId = null, TransferType? type = null, CancellationToken ct = default);
 
     /// <summary>
     /// Preset info for switching account mode
@@ -712,7 +712,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="riskOffsetType">["<c>riskOffsetType</c>"] Risk offset type, applicable when switching from Spot and futures mode or Multi-currency margin mode to Portfolio margin mode.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXPresetAccountMode>> PresetAccountModeSwitchAsync(AccountLevel mode, int? leverage = null, RiskOffsetType? riskOffsetType = null, CancellationToken ct = default);
+    Task<HttpResult<OKXPresetAccountMode>> PresetAccountModeSwitchAsync(AccountLevel mode, int? leverage = null, RiskOffsetType? riskOffsetType = null, CancellationToken ct = default);
 
     /// <summary>
     /// Run a pre-check for account mode switching
@@ -726,7 +726,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="mode">["<c>acctLv</c>"] Account mode</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAccountSwitchCheckResult>> PrecheckAccountModeSwitchAsync(AccountLevel mode, CancellationToken ct = default);
+    Task<HttpResult<OKXAccountSwitchCheckResult>> PrecheckAccountModeSwitchAsync(AccountLevel mode, CancellationToken ct = default);
 
     /// <summary>
     /// Set the account mode
@@ -740,7 +740,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="mode">["<c>acctLv</c>"] New account mode</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAccountMode>> SetAccountModeAsync(AccountLevel mode, CancellationToken ct = default);
+    Task<HttpResult<OKXAccountMode>> SetAccountModeAsync(AccountLevel mode, CancellationToken ct = default);
 
     /// <summary>
     /// Get details of an affiliate invitee
@@ -754,7 +754,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="userId">["<c>uid</c>"] User id</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXInviteeDetails>> GetAffiliateInviteeDetailsAsync(string userId, CancellationToken ct = default);
+    Task<HttpResult<OKXInviteeDetails>> GetAffiliateInviteeDetailsAsync(string userId, CancellationToken ct = default);
 
     /// <summary>
     /// Get asset valuation
@@ -768,7 +768,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="asset">["<c>ccy</c>"] The asset to denote the value in, defaults to BTC</param>
     /// <param name="ct"></param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAssetValuation>> GetAssetValuationAsync(string? asset = null, CancellationToken ct = default);
+    Task<HttpResult<OKXAssetValuation>> GetAssetValuationAsync(string? asset = null, CancellationToken ct = default);
 
     /// <summary>
     /// Manually borrow / repay. Only applicable to Spot mode
@@ -783,7 +783,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="BorrowRepaySide">["<c>side</c>"] Borrow or repay</param>
     /// <param name="quantity">["<c>amt</c>"] Quantity</param>
     /// <param name="ct">Cancellation token</param>
-    Task<WebCallResult<OKXBorrowRepayResult>> ManualBorrowRepay(string asset, BorrowRepaySide BorrowRepaySide, decimal quantity, CancellationToken ct = default);
+    Task<HttpResult<OKXBorrowRepayResult>> ManualBorrowRepay(string asset, BorrowRepaySide BorrowRepaySide, decimal quantity, CancellationToken ct = default);
 
     /// <summary>
     /// Set auto repay. Only applicable to Spot mode
@@ -796,7 +796,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// </summary>
     /// <param name="autoRepay">["<c>autoRepay</c>"] Auto repay enabled or not</param>
     /// <param name="ct">Cancellation token</param>
-    Task<WebCallResult<OKXAutoRepayStatus>> SetAutoRepayAsync(bool autoRepay, CancellationToken ct = default);
+    Task<HttpResult<OKXAutoRepayStatus>> SetAutoRepayAsync(bool autoRepay, CancellationToken ct = default);
 
     /// <summary>
     /// Get borrow/repay history
@@ -813,7 +813,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="endTime">["<c>before</c>"] Filter by end time</param>
     /// <param name="limit">["<c>limit</c>"] Max number of results</param>
     /// <param name="ct">Cancellation token</param>
-    Task<WebCallResult<OKXBorrowRepayEntry[]>> GetBorrowRepayHistoryAsync(string? asset = null, BorrowRepayType? type = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default);
+    Task<HttpResult<OKXBorrowRepayEntry[]>> GetBorrowRepayHistoryAsync(string? asset = null, BorrowRepayType? type = null, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get a list of instruments that are available to the user
@@ -829,7 +829,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// <param name="symbol">["<c>instId</c>"] Filter by symbol, for example `ETH-USDT`</param>
     /// <param name="instrumentFamily">["<c>instFamily</c>"] Instrument family</param>
     /// <param name="ct">Cancellation Token</param>
-    Task<WebCallResult<OKXInstrument[]>> GetSymbolsAsync(InstrumentType instrumentType, string? underlying = null, string? symbol = null, string? instrumentFamily = null, CancellationToken ct = default);
+    Task<HttpResult<OKXInstrument[]>> GetSymbolsAsync(InstrumentType instrumentType, string? underlying = null, string? symbol = null, string? instrumentFamily = null, CancellationToken ct = default);
 
     /// <summary>
     /// Set fee charge type for spot trading
@@ -842,7 +842,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// </summary>
     /// <param name="feeType">["<c>feeType</c>"] Fee type</param>
     /// <param name="ct">Cancellation Token</param>
-    Task<WebCallResult<OKXFeeType>> SetFeeTypeAsync(FeeType feeType, CancellationToken ct = default);
+    Task<HttpResult<OKXFeeType>> SetFeeTypeAsync(FeeType feeType, CancellationToken ct = default);
 
     /// <summary>
     /// Set settlement asset for USD contracts
@@ -855,7 +855,7 @@ public interface IOKXRestClientUnifiedApiAccount
     /// </summary>
     /// <param name="settleAsset">["<c>settleCcy</c>"] The settlement asset</param>
     /// <param name="ct">Cancellation Token</param>
-    Task<WebCallResult<OKXSettleAsset>> SetSettleAssetAsync(string settleAsset, CancellationToken ct = default);
+    Task<HttpResult<OKXSettleAsset>> SetSettleAssetAsync(string settleAsset, CancellationToken ct = default);
 
     /// <summary>
     /// Get greeks values. Only applicable to option contracts. 
@@ -868,6 +868,6 @@ public interface IOKXRestClientUnifiedApiAccount
     /// </summary>
     /// <param name="asset">Filter by asset</param>
     /// <param name="ct">Cancellation Token</param>
-    Task<WebCallResult<OKXGreeks[]>> GetGreeksAsync(string? asset = null, CancellationToken ct = default);
+    Task<HttpResult<OKXGreeks[]>> GetGreeksAsync(string? asset = null, CancellationToken ct = default);
 }
 

--- a/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXRestClientUnifiedApiCopyTrading.cs
+++ b/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXRestClientUnifiedApiCopyTrading.cs
@@ -18,7 +18,7 @@ public interface IOKXRestClientUnifiedApiCopyTrading
     /// </summary>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXCopyTradingAccount>> GetAccountConfigurationAsync(CancellationToken ct = default);
+    Task<HttpResult<OKXCopyTradingAccount>> GetAccountConfigurationAsync(CancellationToken ct = default);
 
     /// <summary>
     /// Get current leading positions of lead trader.
@@ -36,7 +36,7 @@ public interface IOKXRestClientUnifiedApiCopyTrading
     /// <param name="limit">["<c>limit</c>"] Number of results per request. Maximum is 100. Default is 100.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXCurrentSubposition[]>> GetLeadTraderCurrentLeadPositionsAsync(string uniqueCode, string instType = "SWAP", string? after = null, string? before = null, int limit = 100,  CancellationToken ct = default);
+    Task<HttpResult<OKXCurrentSubposition[]>> GetLeadTraderCurrentLeadPositionsAsync(string uniqueCode, string instType = "SWAP", string? after = null, string? before = null, int limit = 100,  CancellationToken ct = default);
 
     /// <summary>
     /// Retrieve lead positions that are not closed.
@@ -54,7 +54,7 @@ public interface IOKXRestClientUnifiedApiCopyTrading
     /// <param name="limit">["<c>limit</c>"] Number of results per request. Maximum is 500. Default is 500.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXCurrentSubposition[]>> GetLeadPositionsAsync(string? symbol = null, Enums.InstrumentType? instrumentType = null, string? after = null, string? before = null, int limit = 500, CancellationToken ct = default);
+    Task<HttpResult<OKXCurrentSubposition[]>> GetLeadPositionsAsync(string? symbol = null, Enums.InstrumentType? instrumentType = null, string? after = null, string? before = null, int limit = 500, CancellationToken ct = default);
 
     /// <summary>
     /// Retrieve the completed lead position of the last 3 months.
@@ -72,7 +72,7 @@ public interface IOKXRestClientUnifiedApiCopyTrading
     /// <param name="limit">["<c>limit</c>"] Number of results per request. Maximum is 100. Default is 100.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXSubpositionHistory[]>> GetLeadPositionHistoryAsync(string? symbol = null, Enums.InstrumentType? instrumentType = null, string? after = null, string? before = null, int limit = 100, CancellationToken ct = default);
+    Task<HttpResult<OKXSubpositionHistory[]>> GetLeadPositionHistoryAsync(string? symbol = null, Enums.InstrumentType? instrumentType = null, string? after = null, string? before = null, int limit = 100, CancellationToken ct = default);
 
     /// <summary>
     /// The leading trader sets TP/SL for the current leading position that are not closed.
@@ -90,7 +90,7 @@ public interface IOKXRestClientUnifiedApiCopyTrading
     /// <param name="stopLossOrderPrice">["<c>slOrdPx</c>"] Stop-loss order price. -1 for market price</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXCopyTradingActionResponse>> PlaceLeadStopOrderAsync(string subPositionId, decimal? takeProfitTriggerPrice = null, decimal? takeProfitOrderPrice = null, decimal? stopLossTriggerPrice = null, decimal? stopLossOrderPrice = null, CancellationToken ct = default);
+    Task<HttpResult<OKXCopyTradingActionResponse>> PlaceLeadStopOrderAsync(string subPositionId, decimal? takeProfitTriggerPrice = null, decimal? takeProfitOrderPrice = null, decimal? stopLossTriggerPrice = null, decimal? stopLossOrderPrice = null, CancellationToken ct = default);
 
     /// <summary>
     /// Close a lead position
@@ -105,7 +105,7 @@ public interface IOKXRestClientUnifiedApiCopyTrading
     /// <param name="instrumentType">["<c>instType</c>"] Instrument type</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXCopyTradingActionResponse>> CloseLeadPositionAsync(string subPositionId, Enums.InstrumentType? instrumentType = null, CancellationToken ct = default);
+    Task<HttpResult<OKXCopyTradingActionResponse>> CloseLeadPositionAsync(string subPositionId, Enums.InstrumentType? instrumentType = null, CancellationToken ct = default);
 
     /// <summary>
     /// Retrieve instruments that are supported to lead by the platform and the lead trader has set.
@@ -119,7 +119,7 @@ public interface IOKXRestClientUnifiedApiCopyTrading
     /// <param name="instrumentType">["<c>instType</c>"] Instrument type</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXLeadingInstrument[]>> GetLeadingInstrumentsAsync(Enums.InstrumentType? instrumentType = null, CancellationToken ct = default);
+    Task<HttpResult<OKXLeadingInstrument[]>> GetLeadingInstrumentsAsync(Enums.InstrumentType? instrumentType = null, CancellationToken ct = default);
 
     /// <summary>
     /// Amend leading instruments
@@ -134,6 +134,6 @@ public interface IOKXRestClientUnifiedApiCopyTrading
     /// <param name="instrumentType">["<c>instType</c>"] Instrument type</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXLeadingInstrument[]>> AmendLeadingInstrumentsAsync(IEnumerable<string> symbols, Enums.InstrumentType? instrumentType = null, CancellationToken ct = default);
+    Task<HttpResult<OKXLeadingInstrument[]>> AmendLeadingInstrumentsAsync(IEnumerable<string> symbols, Enums.InstrumentType? instrumentType = null, CancellationToken ct = default);
 }
 

--- a/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXRestClientUnifiedApiExchangeData.cs
+++ b/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXRestClientUnifiedApiExchangeData.cs
@@ -21,7 +21,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// </summary>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKX24HourVolume>> Get24HourVolumeAsync(CancellationToken ct = default);
+    Task<HttpResult<OKX24HourVolume>> Get24HourVolumeAsync(CancellationToken ct = default);
 
     /// <summary>
     /// Get block ticker. Retrieve the latest block trading volume in the last 24 hours.
@@ -35,7 +35,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="symbol">["<c>instId</c>"] Symbol, for example `BTC-USD-SWAP`</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXBlockTicker>> GetBlockTickerAsync(string symbol, CancellationToken ct = default);
+    Task<HttpResult<OKXBlockTicker>> GetBlockTickerAsync(string symbol, CancellationToken ct = default);
 
     /// <summary>
     /// Get block tickers. Retrieve the latest block trading volume in the last 24 hours.
@@ -51,7 +51,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="instrumentFamily">["<c>instFamily</c>"] Instrument family</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXBlockTicker[]>> GetBlockTickersAsync(InstrumentType instrumentType, string? underlying = null, string? instrumentFamily = null, CancellationToken ct = default);
+    Task<HttpResult<OKXBlockTicker[]>> GetBlockTickersAsync(InstrumentType instrumentType, string? underlying = null, string? instrumentFamily = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get block trades. Retrieve the recent block trading transactions of an instrument. Descending order by tradeId.
@@ -65,7 +65,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="symbol">["<c>instId</c>"] Symbol, for example `BTC-USD-SWAP`</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXBlockTrade[]>> GetBlockTradesAsync(string symbol, CancellationToken ct = default);
+    Task<HttpResult<OKXBlockTrade[]>> GetBlockTradesAsync(string symbol, CancellationToken ct = default);
 
     /// <summary>
     /// Get the estimated delivery price, which will only have a return value one hour before the delivery/exercise.
@@ -84,7 +84,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="instrumentFamily">["<c>instFamily</c>"] Instrument family</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXDeliveryExerciseHistory[]>> GetDeliveryExerciseHistoryAsync(InstrumentType instrumentType, string? underlying = null, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, string? instrumentFamily = null, CancellationToken ct = default);
+    Task<HttpResult<OKXDeliveryExerciseHistory[]>> GetDeliveryExerciseHistoryAsync(InstrumentType instrumentType, string? underlying = null, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, string? instrumentFamily = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get discount rate level and interest-free quota.
@@ -98,7 +98,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="discountLevel">["<c>discountLv</c>"] Discount level</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXDiscountInfo[]>> GetDiscountInfoAsync(int? discountLevel = null, CancellationToken ct = default);
+    Task<HttpResult<OKXDiscountInfo[]>> GetDiscountInfoAsync(int? discountLevel = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get the estimated delivery price which will only have a return value one hour before the delivery/exercise.
@@ -112,7 +112,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="symbol">["<c>instId</c>"] Symbol, for example `BTC-USD-200214`</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXEstimatedPrice>> GetEstimatedPriceAsync(string symbol, CancellationToken ct = default);
+    Task<HttpResult<OKXEstimatedPrice>> GetEstimatedPriceAsync(string symbol, CancellationToken ct = default);
 
     /// <summary>
     /// Get funding rate history. This endpoint can retrieve data from the last 3 months.
@@ -129,7 +129,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="limit">["<c>limit</c>"] Number of results per request. The maximum is 400; the default is 100.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXFundingRateHistory[]>> GetFundingRateHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
+    Task<HttpResult<OKXFundingRateHistory[]>> GetFundingRateHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
 
     /// <summary>
     /// Get funding rates
@@ -143,7 +143,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="symbol">["<c>instId</c>"] Symbol, for example `BTC-USD-SWAP`. If not provided funding rates for all SWAP symbols will be returned</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXFundingRate[]>> GetFundingRatesAsync(string? symbol = null, CancellationToken ct = default);
+    Task<HttpResult<OKXFundingRate[]>> GetFundingRatesAsync(string? symbol = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get the index component information data on the market
@@ -157,7 +157,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="index">["<c>index</c>"] Index, for example `BTC-USD`</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXIndexComponents>> GetIndexComponentsAsync(string index, CancellationToken ct = default);
+    Task<HttpResult<OKXIndexComponents>> GetIndexComponentsAsync(string index, CancellationToken ct = default);
 
     /// <summary>
     /// Get the kline/candlestick data of the index. This endpoint can retrieve the latest 1,440 data entries. Charts are returned in groups based on the requested bar.
@@ -175,7 +175,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="limit">["<c>limit</c>"] Number of results per request. The maximum is 100; the default is 100.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXKline[]>> GetIndexKlinesAsync(string symbol, KlineInterval period, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
+    Task<HttpResult<OKXKline[]>> GetIndexKlinesAsync(string symbol, KlineInterval period, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
 
     /// <summary>
     /// Get index tickers.
@@ -190,7 +190,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="symbol">["<c>instId</c>"] Symbol, for example `BTC-USD`</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXIndexTicker[]>> GetIndexTickersAsync(string? quoteAsset = null, string? symbol = null, CancellationToken ct = default);
+    Task<HttpResult<OKXIndexTicker[]>> GetIndexTickersAsync(string? quoteAsset = null, string? symbol = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get a list of instruments with open contracts.
@@ -207,7 +207,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="instrumentFamily">["<c>instFamily</c>"] Instrument family</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXInstrument[]>> GetSymbolsAsync(InstrumentType instrumentType, string? underlying = null, string? symbol = null, string? instrumentFamily = null, CancellationToken ct = default);
+    Task<HttpResult<OKXInstrument[]>> GetSymbolsAsync(InstrumentType instrumentType, string? underlying = null, string? symbol = null, string? instrumentFamily = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get insurance fund balance information
@@ -228,7 +228,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="instrumentFamily">["<c>instFamily</c>"] Instrument family</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXInsuranceFund>> GetInsuranceFundAsync(InstrumentType instrumentType, InsuranceType type = InsuranceType.All, string? underlying = null, string? asset = null, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, string? instrumentFamily = null, CancellationToken ct = default);
+    Task<HttpResult<OKXInsuranceFund>> GetInsuranceFundAsync(InstrumentType instrumentType, InsuranceType type = InsuranceType.All, string? underlying = null, string? asset = null, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, string? instrumentFamily = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get margin interest rate
@@ -241,7 +241,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// </summary>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXInterestRate>> GetInterestRatesAsync(CancellationToken ct = default);
+    Task<HttpResult<OKXInterestRate>> GetInterestRatesAsync(CancellationToken ct = default);
 
     /// <summary>
     /// Get history kline/candlestick data from recent years.
@@ -259,7 +259,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="limit">["<c>limit</c>"] Number of results per request. The maximum is 300; the default is 100.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXKline[]>> GetKlineHistoryAsync(string symbol, KlineInterval period, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
+    Task<HttpResult<OKXKline[]>> GetKlineHistoryAsync(string symbol, KlineInterval period, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
 
     /// <summary>
     /// Get the kline/candlestick data. This endpoint can retrieve the latest 1,440 data entries. Charts are returned in groups based on the requested bar.
@@ -277,7 +277,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="limit">["<c>limit</c>"] Number of results per request. The maximum is 300; the default is 100.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXKline[]>> GetKlinesAsync(string symbol, KlineInterval period, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
+    Task<HttpResult<OKXKline[]>> GetKlinesAsync(string symbol, KlineInterval period, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
 
     /// <summary>
     /// Get the highest buy limit and lowest sell limit of the instrument.
@@ -291,7 +291,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="symbol">["<c>instId</c>"] Symbol, for example `ETH-USDT`</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXLimitPrice>> GetPriceLimitsAsync(string symbol, CancellationToken ct = default);
+    Task<HttpResult<OKXLimitPrice>> GetPriceLimitsAsync(string symbol, CancellationToken ct = default);
 
     /// <summary>
     /// Get the kline/candlestick data of the mark price. This endpoint can retrieve the latest 1,440 data entries. Charts are returned in groups based on the requested bar.
@@ -309,7 +309,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="limit">["<c>limit</c>"] Number of results per request. The maximum is 100; the default is 100.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXKline[]>> GetMarkPriceKlinesAsync(string symbol, KlineInterval period, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
+    Task<HttpResult<OKXKline[]>> GetMarkPriceKlinesAsync(string symbol, KlineInterval period, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
 
     /// <summary>
     /// Get mark price. Mark price is set based on the SPOT index and at a reasonable basis to prevent individual users from manipulating the market and causing the contract price to fluctuate.
@@ -326,7 +326,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="instrumentFamily">["<c>instFamily</c>"] Instrument family</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXMarkPrice[]>> GetMarkPricesAsync(InstrumentType instrumentType, string? underlying = null, string? symbol = null, string? instrumentFamily = null, CancellationToken ct = default);
+    Task<HttpResult<OKXMarkPrice[]>> GetMarkPricesAsync(InstrumentType instrumentType, string? underlying = null, string? symbol = null, string? instrumentFamily = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get the total open interest for contracts on OKX.
@@ -343,7 +343,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="instrumentFamily">["<c>instFamily</c>"] Instrument family</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXOpenInterest[]>> GetOpenInterestsAsync(InstrumentType instrumentType, string? underlying = null, string? symbol = null, string? instrumentFamily = null, CancellationToken ct = default);
+    Task<HttpResult<OKXOpenInterest[]>> GetOpenInterestsAsync(InstrumentType instrumentType, string? underlying = null, string? symbol = null, string? instrumentFamily = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get option market data.
@@ -359,7 +359,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="instrumentFamily">["<c>instFamily</c>"] Instrument type</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXOptionSummary[]>> GetOptionMarketDataAsync(string underlying, DateTime? expiryDate = null, string? instrumentFamily = null, CancellationToken ct = default);
+    Task<HttpResult<OKXOptionSummary[]>> GetOptionMarketDataAsync(string underlying, DateTime? expiryDate = null, string? instrumentFamily = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get a symbol order book.
@@ -374,7 +374,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="depth">["<c>sz</c>"] Order book depth per side. Maximum 400, e.g. 400 bids + 400 asks. Default returns to 1 depth data</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXOrderBook>> GetOrderBookAsync(string symbol, int depth = 1, CancellationToken ct = default);
+    Task<HttpResult<OKXOrderBook>> GetOrderBookAsync(string symbol, int depth = 1, CancellationToken ct = default);
 
     /// <summary>
     /// Get position information，Maximum leverage depends on your borrowings and margin ratio.
@@ -394,7 +394,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="instrumentFamily">["<c>instFamily</c>"] Instrument family</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXPositionTier[]>> GetPositionTiersAsync(
+    Task<HttpResult<OKXPositionTier[]>> GetPositionTiersAsync(
         InstrumentType instrumentType,
         MarginMode marginMode,
         string underlying,
@@ -417,7 +417,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="limit">["<c>limit</c>"] Number of results per request. The maximum is 100; the default is 100.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXTrade[]>> GetRecentTradesAsync(string symbol, int limit = 100, CancellationToken ct = default);
+    Task<HttpResult<OKXTrade[]>> GetRecentTradesAsync(string symbol, int limit = 100, CancellationToken ct = default);
 
     /// <summary>
     /// Get open interest and trading volume
@@ -434,7 +434,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="endTime">["<c>end</c>"] Pagination of data to return records newer than the requested ts</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXInterestVolume[]>> GetTradeStatsContractSummaryAsync(string asset, KlineInterval period = KlineInterval.FiveMinutes, DateTime? startTime = null, DateTime? endTime = null, CancellationToken ct = default);
+    Task<HttpResult<OKXInterestVolume[]>> GetTradeStatsContractSummaryAsync(string asset, KlineInterval period = KlineInterval.FiveMinutes, DateTime? startTime = null, DateTime? endTime = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get the volume and open interest for each upcoming expiration. You can use this to see which expirations are currently the most popular to trade.
@@ -449,7 +449,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="period">["<c>period</c>"] period, the default is 8H. e.g. [8H/1D]</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXInterestVolumeExpiry[]>> GetTradeStatsInterestVolumeExpiryAsync(string asset, KlineInterval period = KlineInterval.FiveMinutes, CancellationToken ct = default);
+    Task<HttpResult<OKXInterestVolumeExpiry[]>> GetTradeStatsInterestVolumeExpiryAsync(string asset, KlineInterval period = KlineInterval.FiveMinutes, CancellationToken ct = default);
 
     /// <summary>
     /// Get what option strikes are the most popular for each expiration.
@@ -465,7 +465,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="period">["<c>period</c>"] period, the default is 8H. e.g. [8H/1D]</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXInterestVolumeStrike[]>> GetTradeStatsInterestVolumeStrikeAsync(string asset, string expiryTime, KlineInterval period = KlineInterval.FiveMinutes, CancellationToken ct = default);
+    Task<HttpResult<OKXInterestVolumeStrike[]>> GetTradeStatsInterestVolumeStrikeAsync(string asset, string expiryTime, KlineInterval period = KlineInterval.FiveMinutes, CancellationToken ct = default);
 
     /// <summary>
     /// Get the ratio of users with net long vs short positions. It includes data from futures and perpetual swaps.
@@ -482,7 +482,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="endTime">["<c>end</c>"] Pagination of data to return records newer than the requested ts</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXRatio[]>> GetTradeStatsLongShortRatioAsync(string asset, KlineInterval period = KlineInterval.FiveMinutes, DateTime? startTime = null, DateTime? endTime = null, CancellationToken ct = default);
+    Task<HttpResult<OKXRatio[]>> GetTradeStatsLongShortRatioAsync(string asset, KlineInterval period = KlineInterval.FiveMinutes, DateTime? startTime = null, DateTime? endTime = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get the ratio of cumulative data value between currency pair leverage quote asset and underlying asset over a given period of time.
@@ -499,7 +499,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="endTime">["<c>end</c>"] Pagination of data to return records newer than the requested ts</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXRatio[]>> GetTradeStatsMarginLendingRatioAsync(string asset, KlineInterval period = KlineInterval.FiveMinutes, DateTime? startTime = null, DateTime? endTime = null, CancellationToken ct = default);
+    Task<HttpResult<OKXRatio[]>> GetTradeStatsMarginLendingRatioAsync(string asset, KlineInterval period = KlineInterval.FiveMinutes, DateTime? startTime = null, DateTime? endTime = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get the sum of all open positions and how much total trading volume has taken place.
@@ -514,7 +514,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="period">["<c>period</c>"] period, the default is 8H. e.g. [8H/1D]</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXInterestVolume[]>> GetTradeStatsOptionsSummaryAsync(string asset, KlineInterval period = KlineInterval.FiveMinutes, CancellationToken ct = default);
+    Task<HttpResult<OKXInterestVolume[]>> GetTradeStatsOptionsSummaryAsync(string asset, KlineInterval period = KlineInterval.FiveMinutes, CancellationToken ct = default);
 
     /// <summary>
     /// Get the relative buy/sell volume for calls and puts. It shows whether traders are bullish or bearish on price and volatility.
@@ -529,7 +529,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="period">["<c>period</c>"] period, the default is 8H. e.g. [8H/1D]</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXPutCallRatio[]>> GetTradeStatsPutCallRatioAsync(string asset, KlineInterval period = KlineInterval.FiveMinutes, CancellationToken ct = default);
+    Task<HttpResult<OKXPutCallRatio[]>> GetTradeStatsPutCallRatioAsync(string asset, KlineInterval period = KlineInterval.FiveMinutes, CancellationToken ct = default);
 
     /// <summary>
     /// Get the assets supported by the transaction big data interface
@@ -542,7 +542,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// </summary>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXSupportCoins>> GetTradeStatsSupportedAssetsAsync(CancellationToken ct = default);
+    Task<HttpResult<OKXSupportCoins>> GetTradeStatsSupportedAssetsAsync(CancellationToken ct = default);
 
     /// <summary>
     /// Get the relative buy/sell volume for calls and puts. It shows whether traders are bullish or bearish on price and volatility.
@@ -557,7 +557,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="period">["<c>period</c>"] period, the default is 8H. e.g. [8H/1D]</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXTakerFlow>> GetTradeStatsTakerFlowAsync(string asset, KlineInterval period = KlineInterval.FiveMinutes, CancellationToken ct = default);
+    Task<HttpResult<OKXTakerFlow>> GetTradeStatsTakerFlowAsync(string asset, KlineInterval period = KlineInterval.FiveMinutes, CancellationToken ct = default);
 
     /// <summary>
     /// Get the taker volume for both buyers and sellers. This shows the influx and exit of funds in and out of {coin}.
@@ -575,7 +575,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="endTime">["<c>end</c>"] Pagination of data to return records newer than the requested ts</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXTakerVolume[]>> GetTradeStatsTakerVolumeAsync(string asset, InstrumentType instrumentType, KlineInterval period = KlineInterval.FiveMinutes, DateTime? startTime = null, DateTime? endTime = null, CancellationToken ct = default);
+    Task<HttpResult<OKXTakerVolume[]>> GetTradeStatsTakerVolumeAsync(string asset, InstrumentType instrumentType, KlineInterval period = KlineInterval.FiveMinutes, DateTime? startTime = null, DateTime? endTime = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get API server time.
@@ -588,7 +588,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// </summary>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default);
+    Task<HttpResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default);
 
     /// <summary>
     /// Get the latest price snapshot, best bid/ask price, and trading volume in the last 24 hours.
@@ -602,7 +602,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="symbol">["<c>instId</c>"] Symbol, for example `ETH-USDT`</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXTicker>> GetTickerAsync(string symbol, CancellationToken ct = default);
+    Task<HttpResult<OKXTicker>> GetTickerAsync(string symbol, CancellationToken ct = default);
 
     /// <summary>
     /// Get the latest price snapshot, best bid/ask price, and trading volume in the last 24 hours.
@@ -618,7 +618,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="instrumentFamily">["<c>instFamily</c>"] Instrument family</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXTicker[]>> GetTickersAsync(InstrumentType instrumentType, string? underlying = null, string? instrumentFamily = null, CancellationToken ct = default);
+    Task<HttpResult<OKXTicker[]>> GetTickersAsync(InstrumentType instrumentType, string? underlying = null, string? instrumentFamily = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get trades history
@@ -636,7 +636,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="limit">["<c>limit</c>"] Number of results per request. The maximum is 100; the default is 100.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXTrade[]>> GetTradeHistoryAsync(string symbol, TradeHistoryPaginationType type = TradeHistoryPaginationType.TradeId, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
+    Task<HttpResult<OKXTrade[]>> GetTradeHistoryAsync(string symbol, TradeHistoryPaginationType type = TradeHistoryPaginationType.TradeId, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
 
     /// <summary>
     /// Get Underlying
@@ -650,7 +650,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="instrumentType">["<c>instType</c>"] Instrument Type</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<string[]>> GetUnderlyingAsync(InstrumentType instrumentType, CancellationToken ct = default);
+    Task<HttpResult<string[]>> GetUnderlyingAsync(InstrumentType instrumentType, CancellationToken ct = default);
 
     /// <summary>
     /// Convert units
@@ -668,7 +668,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="quantity">["<c>sz</c>"] Quantity to buy or sell</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXUnitConvert>> UnitConvertAsync(ConvertType type, string symbol, decimal quantity, ConvertUnit? unit = null, decimal? price = null, CancellationToken ct = default);
+    Task<HttpResult<OKXUnitConvert>> UnitConvertAsync(ConvertType type, string symbol, decimal quantity, ConvertUnit? unit = null, decimal? price = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get announcements
@@ -682,7 +682,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="announcementType">["<c>annType</c>"] Announcement type filter</param>
     /// <param name="page">["<c>page</c>"] Page number</param>
     /// <param name="ct">Cancellation token</param>
-    Task<WebCallResult<OKXAnnouncementsPage>> GetAnnouncementsAsync(string? announcementType = null, int? page = null, CancellationToken ct = default);
+    Task<HttpResult<OKXAnnouncementsPage>> GetAnnouncementsAsync(string? announcementType = null, int? page = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get a list of different announcement type values
@@ -694,7 +694,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// </para>
     /// </summary>
     /// <param name="ct">Cancellation token</param>
-    Task<WebCallResult<OKXAnnouncementType[]>> GetAnnouncementTypesAsync(CancellationToken ct = default);
+    Task<HttpResult<OKXAnnouncementType[]>> GetAnnouncementTypesAsync(CancellationToken ct = default);
 
     /// <summary>
     /// Get estimated futures settlement price
@@ -708,7 +708,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="symbol">["<c>instId</c>"] Symbol name, for example `XRP-USDT-250307`</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXSettlementPrice>> GetEstimatedFuturesSettlementPriceAsync(string symbol, CancellationToken ct = default);
+    Task<HttpResult<OKXSettlementPrice>> GetEstimatedFuturesSettlementPriceAsync(string symbol, CancellationToken ct = default);
 
     /// <summary>
     /// Get settlement history
@@ -725,7 +725,7 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="limit">["<c>limit</c>"] Max number of results</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXSettlementInfo[]>> GetSettlementHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default);
+    Task<HttpResult<OKXSettlementInfo[]>> GetSettlementHistoryAsync(string symbol, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get premium history
@@ -742,6 +742,6 @@ public interface IOKXRestClientUnifiedApiExchangeData
     /// <param name="limit">["<c>limit</c>"] Max number of results</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXPremiumHistory[]>> GetPremiumHistoryAsync(string instrumentId, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default);
+    Task<HttpResult<OKXPremiumHistory[]>> GetPremiumHistoryAsync(string instrumentId, DateTime? startTime = null, DateTime? endTime = null, int? limit = null, CancellationToken ct = default);
 }
 

--- a/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXRestClientUnifiedApiSubAccounts.cs
+++ b/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXRestClientUnifiedApiSubAccounts.cs
@@ -26,7 +26,7 @@ public interface IOKXRestClientUnifiedApiSubAccounts
     /// <param name="limit">["<c>limit</c>"] Number of results per request. The maximum is 100; the default is 100.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXSubAccountBill[]>> GetSubAccountBillsAsync(string? subAccountName = null, string? asset = null, SubAccountTransferType? type = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, CancellationToken ct = default);
+    Task<HttpResult<OKXSubAccountBill[]>> GetSubAccountBillsAsync(string? subAccountName = null, string? asset = null, SubAccountTransferType? type = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, CancellationToken ct = default);
 
     /// <summary>
     /// Get sub-account funding balance
@@ -42,7 +42,7 @@ public interface IOKXRestClientUnifiedApiSubAccounts
     /// <param name="asset">["<c>ccy</c>"] Single asset or multiple assets (no more than 20) separated with comma, e.g. BTC or BTC,ETH.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXSubAccountFundingBalance[]>> GetSubAccountFundingBalancesAsync(string subAccountName, string? asset = null, CancellationToken ct = default);
+    Task<HttpResult<OKXSubAccountFundingBalance[]>> GetSubAccountFundingBalancesAsync(string subAccountName, string? asset = null, CancellationToken ct = default);
 
     /// <summary>
     /// applies to master accounts only
@@ -60,7 +60,7 @@ public interface IOKXRestClientUnifiedApiSubAccounts
     /// <param name="limit">["<c>limit</c>"] Number of results per request. The maximum is 100; the default is 100.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXSubAccount[]>> GetSubAccountsAsync(bool? enable = null, string? subAccountName = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, CancellationToken ct = default);
+    Task<HttpResult<OKXSubAccount[]>> GetSubAccountsAsync(bool? enable = null, string? subAccountName = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, CancellationToken ct = default);
 
     /// <summary>
     /// Query detailed balance info of Trading Account of a sub-account via the master account (applies to master accounts only)
@@ -74,7 +74,7 @@ public interface IOKXRestClientUnifiedApiSubAccounts
     /// <param name="subAccountName">["<c>subAcct</c>"] Sub Account Name</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAccountBalance>> GetSubAccountTradingBalancesAsync(string subAccountName, CancellationToken ct = default);
+    Task<HttpResult<OKXAccountBalance>> GetSubAccountTradingBalancesAsync(string subAccountName, CancellationToken ct = default);
 
     /// <summary>
     /// applies to master accounts only
@@ -93,7 +93,7 @@ public interface IOKXRestClientUnifiedApiSubAccounts
     /// <param name="ipAddresses">["<c>ip</c>"] Link IP addresses, separate with commas if more than one. Support up to 20 IP addresses.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXSubAccountApiKey>> ResetSubAccountApiKeyAsync(string subAccountName, string apiKey, string? apiLabel = null, bool? readPermission = null, bool? tradePermission = null, string? ipAddresses = null, CancellationToken ct = default);
+    Task<HttpResult<OKXSubAccountApiKey>> ResetSubAccountApiKeyAsync(string subAccountName, string apiKey, string? apiLabel = null, bool? readPermission = null, bool? tradePermission = null, string? ipAddresses = null, CancellationToken ct = default);
 
     /// <summary>
     /// applies to master accounts only
@@ -112,7 +112,7 @@ public interface IOKXRestClientUnifiedApiSubAccounts
     /// <param name="toSubAccountName">["<c>toSubAccount</c>"] Sub-account name of the account that transfers funds in.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXSubAccountTransfer>> TransferBetweenSubAccountsAsync(string asset, decimal amount, AccountType fromAccount, AccountType toAccount, string fromSubAccountName, string toSubAccountName, CancellationToken ct = default);
+    Task<HttpResult<OKXSubAccountTransfer>> TransferBetweenSubAccountsAsync(string asset, decimal amount, AccountType fromAccount, AccountType toAccount, string fromSubAccountName, string toSubAccountName, CancellationToken ct = default);
 
     /// <summary>
     /// Find the maximum withdrawal amount for a sub-account.
@@ -127,7 +127,7 @@ public interface IOKXRestClientUnifiedApiSubAccounts
     /// <param name="asset">["<c>ccy</c>"] Asset, for example `ETH`</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXSubAccountMaxWithdrawal[]>> GetSubAccountMaxWithdrawalsAsync(string subAccountName, string? asset = null, CancellationToken ct = default);
+    Task<HttpResult<OKXSubAccountMaxWithdrawal[]>> GetSubAccountMaxWithdrawalsAsync(string subAccountName, string? asset = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get the transfer history of managed sub-accounts.
@@ -146,7 +146,7 @@ public interface IOKXRestClientUnifiedApiSubAccounts
     /// <param name="limit">["<c>limit</c>"] Number of results per request. The maximum is 100; the default is 100.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXSubAccountBill[]>> GetManagedSubAccountBillsAsync(string? subAccountName = null, string? asset = null, SubAccountTransferType? type = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, CancellationToken ct = default);
+    Task<HttpResult<OKXSubAccountBill[]>> GetManagedSubAccountBillsAsync(string? subAccountName = null, string? asset = null, SubAccountTransferType? type = null, DateTime? endTime = null, DateTime? startTime = null, int limit = 100, CancellationToken ct = default);
 
     /// <summary>
     /// Get entrust sub-account list
@@ -160,7 +160,7 @@ public interface IOKXRestClientUnifiedApiSubAccounts
     /// <param name="subAccountName">["<c>subAcct</c>"] Sub Account Name</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXEntrustSubAccount[]>> GetEntrustSubAccountsAsync(string? subAccountName = null, CancellationToken ct = default);
+    Task<HttpResult<OKXEntrustSubAccount[]>> GetEntrustSubAccountsAsync(string? subAccountName = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get sub-account API keys
@@ -175,7 +175,7 @@ public interface IOKXRestClientUnifiedApiSubAccounts
     /// <param name="apiKey">["<c>apiKey</c>"] API key to query</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXSubAccountApiKey[]>> GetSubAccountApiKeysAsync(string subAccountName, string? apiKey = null, CancellationToken ct = default);
+    Task<HttpResult<OKXSubAccountApiKey[]>> GetSubAccountApiKeysAsync(string subAccountName, string? apiKey = null, CancellationToken ct = default);
 
     /// <summary>
     /// Create an API Key for a sub-account
@@ -194,7 +194,7 @@ public interface IOKXRestClientUnifiedApiSubAccounts
     /// <param name="ipAddresses">["<c>ip</c>"] IP Addresses</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXSubAccountApiKey>> CreateSubAccountApiKeyAsync(string subAccountName, string apiLabel, string passphrase, bool readPermission = true, bool tradePermission = false, string? ipAddresses = null, CancellationToken ct = default);
+    Task<HttpResult<OKXSubAccountApiKey>> CreateSubAccountApiKeyAsync(string subAccountName, string apiLabel, string passphrase, bool readPermission = true, bool tradePermission = false, string? ipAddresses = null, CancellationToken ct = default);
 
     /// <summary>
     /// Delete a sub-account API Key
@@ -209,7 +209,7 @@ public interface IOKXRestClientUnifiedApiSubAccounts
     /// <param name="apiKey">["<c>apiKey</c>"] API Key</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXSubAccountApiKey>> DeleteSubAccountApiKeyAsync(string subAccountName, string apiKey, CancellationToken ct = default);
+    Task<HttpResult<OKXSubAccountApiKey>> DeleteSubAccountApiKeyAsync(string subAccountName, string apiKey, CancellationToken ct = default);
 
     /// <summary>
     /// Set sub-account transfer out permissions
@@ -224,7 +224,7 @@ public interface IOKXRestClientUnifiedApiSubAccounts
     /// <param name="canTransferOut">["<c>canTransOut</c>"] Can transfer out</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXSubAccount>> SetSubAccountTransferOutAsync(string subAccountName, bool canTransferOut, CancellationToken ct = default);
+    Task<HttpResult<OKXSubAccount>> SetSubAccountTransferOutAsync(string subAccountName, bool canTransferOut, CancellationToken ct = default);
 
     /// <summary>
     /// Create a new sub-account
@@ -239,6 +239,6 @@ public interface IOKXRestClientUnifiedApiSubAccounts
     /// <param name="label">["<c>label</c>"] Label</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXSubAccount>> CreateSubAccountAsync(string subAccountName, string? label = null, CancellationToken ct = default);
+    Task<HttpResult<OKXSubAccount>> CreateSubAccountAsync(string subAccountName, string? label = null, CancellationToken ct = default);
 }
 

--- a/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXRestClientUnifiedApiTrading.cs
+++ b/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXRestClientUnifiedApiTrading.cs
@@ -20,7 +20,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="orders">Orders</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXOrderAmendResponse[]>> AmendMultipleOrdersAsync(IEnumerable<OKXOrderAmendRequest> orders, CancellationToken ct = default);
+    Task<HttpResult<OKXOrderAmendResponse[]>> AmendMultipleOrdersAsync(IEnumerable<OKXOrderAmendRequest> orders, CancellationToken ct = default);
 
     /// <summary>
     /// Edit an incomplete order.
@@ -48,7 +48,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="priceAmendType">["<c>pxAmendType</c>"] Price amendment type. 0: Do not allow amendment, 1: Allow amendment to best available price within limit</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXOrderAmendResponse>> AmendOrderAsync(
+    Task<HttpResult<OKXOrderAmendResponse>> AmendOrderAsync(
         string symbol,
         long? orderId = null,
         string? clientOrderId = null,
@@ -78,7 +78,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="orders">Orders</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAlgoOrderResponse>> CancelAlgoOrderAsync(IEnumerable<OKXAlgoOrderRequest> orders, CancellationToken ct = default);
+    Task<HttpResult<OKXAlgoOrderResponse>> CancelAlgoOrderAsync(IEnumerable<OKXAlgoOrderRequest> orders, CancellationToken ct = default);
 
     /// <summary>
     /// Cancel all pending orders after a certain time. Recalling this endpoint resets the timeout. Sending TimeSpan.Zero disables the countdown
@@ -93,7 +93,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="tag">["<c>tag</c>"] Only cancel orders with this Tag</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXCancelAllAfterResponse>> CancelAllAfterAsync(TimeSpan timeout, string? tag = null, CancellationToken ct = default);
+    Task<HttpResult<OKXCancelAllAfterResponse>> CancelAllAfterAsync(TimeSpan timeout, string? tag = null, CancellationToken ct = default);
 
     /// <summary>
     /// Cancel incomplete orders in batches. Maximum 20 orders can be canceled at a time. Request parameters should be passed in the form of an array.
@@ -107,7 +107,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="orders">Orders</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXOrderCancelResponse[]>> CancelMultipleOrdersAsync(IEnumerable<OKXOrderCancelRequest> orders, CancellationToken ct = default);
+    Task<HttpResult<OKXOrderCancelResponse[]>> CancelMultipleOrdersAsync(IEnumerable<OKXOrderCancelRequest> orders, CancellationToken ct = default);
 
     /// <summary>
     /// Cancel an incomplete order.
@@ -123,7 +123,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="clientOrderId">["<c>clOrdId</c>"] Client Order ID</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXOrderCancelResponse>> CancelOrderAsync(string symbol, long? orderId = null, string? clientOrderId = null, CancellationToken ct = default);
+    Task<HttpResult<OKXOrderCancelResponse>> CancelOrderAsync(string symbol, long? orderId = null, string? clientOrderId = null, CancellationToken ct = default);
 
     /// <summary>
     /// Close all positions of an instrument via a market order.
@@ -142,7 +142,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="clientOrderId">["<c>clOrdId</c>"] Client order id</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXClosePositionResponse>> ClosePositionAsync(string symbol, MarginMode marginMode, PositionSide? positionSide = null, string? asset = null, bool? autoCancel = null, string? clientOrderId = null, CancellationToken ct = default);
+    Task<HttpResult<OKXClosePositionResponse>> ClosePositionAsync(string symbol, MarginMode marginMode, PositionSide? positionSide = null, string? asset = null, bool? autoCancel = null, string? clientOrderId = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get a list of untriggered Algo orders under the current account.
@@ -163,7 +163,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="limit">["<c>limit</c>"] Number of results per request. The maximum is 100; the default is 100.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAlgoOrder[]>> GetAlgoOrderHistoryAsync(AlgoOrderType algoOrderType, AlgoOrderState? algoOrderState = null, string? algoId = null, InstrumentType? instrumentType = null, string? symbol = null, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
+    Task<HttpResult<OKXAlgoOrder[]>> GetAlgoOrderHistoryAsync(AlgoOrderType algoOrderType, AlgoOrderState? algoOrderState = null, string? algoId = null, InstrumentType? instrumentType = null, string? symbol = null, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
 
     /// <summary>
     /// Get a list of untriggered Algo orders under the current account.
@@ -183,7 +183,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="limit">["<c>limit</c>"] Number of results per request. The maximum is 100; the default is 100.</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAlgoOrder[]>> GetAlgoOrderListAsync(AlgoOrderType algoOrderType, string? algoId = null, InstrumentType? instrumentType = null, string? symbol = null, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
+    Task<HttpResult<OKXAlgoOrder[]>> GetAlgoOrderListAsync(AlgoOrderType algoOrderType, string? algoId = null, InstrumentType? instrumentType = null, string? symbol = null, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
 
     /// <summary>
     /// Get the completed order data of the last 3 months, and the incomplete orders that have been canceled are only reserved for 2 hours.
@@ -208,7 +208,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="toId">["<c>before</c>"] Pagination of data to return records newer than the requested ordId</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXOrder[]>> GetOrderArchiveAsync(InstrumentType instrumentType, string? symbol = null, string? underlying = null, OrderType? orderType = null, OrderStatus? state = null, OrderCategory? category = null, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, string? fromId = null, string? toId = null, string? instrumentFamily = null, CancellationToken ct = default);
+    Task<HttpResult<OKXOrder[]>> GetOrderArchiveAsync(InstrumentType instrumentType, string? symbol = null, string? underlying = null, OrderType? orderType = null, OrderStatus? state = null, OrderCategory? category = null, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, string? fromId = null, string? toId = null, string? instrumentFamily = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get order details.
@@ -224,7 +224,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="clientOrderId">["<c>clOrdId</c>"] Client Order ID</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXOrder>> GetOrderDetailsAsync(string symbol, long? orderId = null, string? clientOrderId = null, CancellationToken ct = default);
+    Task<HttpResult<OKXOrder>> GetOrderDetailsAsync(string symbol, long? orderId = null, string? clientOrderId = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get the completed order data for the last 7 days, and the incomplete orders that have been cancelled are only reserved for 2 hours.
@@ -249,7 +249,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="toId">["<c>before</c>"] Pagination of data to return records newer than the requested ordId</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXOrder[]>> GetOrderHistoryAsync(InstrumentType instrumentType, string? symbol = null, string? underlying = null, OrderType? orderType = null, OrderStatus? state = null, OrderCategory? category = null, DateTime? startTime = null, DateTime? endTime = null, int limit = 100,
+    Task<HttpResult<OKXOrder[]>> GetOrderHistoryAsync(InstrumentType instrumentType, string? symbol = null, string? underlying = null, OrderType? orderType = null, OrderStatus? state = null, OrderCategory? category = null, DateTime? startTime = null, DateTime? endTime = null, int limit = 100,
         string? instrumentFamily = null,
         string? fromId = null,
         string? toId = null,
@@ -275,7 +275,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="instrumentFamily">["<c>instFamily</c>"] Instrument family</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXOrder[]>> GetOrdersAsync(InstrumentType? instrumentType = null, string? symbol = null, string? underlying = null, OrderType? orderType = null, OrderStatus? state = null, string? fromId = null, string? toId = null, int limit = 100, string? instrumentFamily = null, CancellationToken ct = default);
+    Task<HttpResult<OKXOrder[]>> GetOrdersAsync(InstrumentType? instrumentType = null, string? symbol = null, string? underlying = null, OrderType? orderType = null, OrderStatus? state = null, string? fromId = null, string? toId = null, int limit = 100, string? instrumentFamily = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get recently-filled transaction details in the last 3 months.
@@ -298,7 +298,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="toId">["<c>before</c>"] Pagination of data to return records newer than the requested ordId</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXTransaction[]>> GetUserTradesArchiveAsync(InstrumentType instrumentType, string? symbol = null, string? underlying = null, long? orderId = null, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, string? instrumentFamily = null, string? fromId = null, string? toId = null, CancellationToken ct = default);
+    Task<HttpResult<OKXTransaction[]>> GetUserTradesArchiveAsync(InstrumentType instrumentType, string? symbol = null, string? underlying = null, long? orderId = null, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, string? instrumentFamily = null, string? fromId = null, string? toId = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get recently-filled transaction details in the last 3 day.
@@ -321,7 +321,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="toId">["<c>before</c>"] Pagination of data to return records newer than the requested ordId</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXTransaction[]>> GetUserTradesAsync(InstrumentType? instrumentType = null, string? symbol = null, string? underlying = null, long? orderId = null, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, string? instrumentFamily = null, string? fromId = null, string? toId = null, CancellationToken ct = default);
+    Task<HttpResult<OKXTransaction[]>> GetUserTradesAsync(InstrumentType? instrumentType = null, string? symbol = null, string? underlying = null, long? orderId = null, DateTime? startTime = null, DateTime? endTime = null, int limit = 100, string? instrumentFamily = null, string? fromId = null, string? toId = null, CancellationToken ct = default);
 
     /// <summary>
     /// Place new algo order. The algo order includes trigger order, oco order, conditional order,iceberg order and twap order.
@@ -369,7 +369,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="advancedOrderType">["<c>advanceOrdType</c>"] Advanced order type for trigger orders</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAlgoOrderResponse>> PlaceAlgoOrderAsync(
+    Task<HttpResult<OKXAlgoOrderResponse>> PlaceAlgoOrderAsync(
         string symbol,
         TradeMode tradeMode,
         OrderSide orderSide,
@@ -419,7 +419,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="orders">Orders</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<CallResult<OKXOrderPlaceResponse>[]>> PlaceMultipleOrdersAsync(IEnumerable<OKXOrderPlaceRequest> orders, CancellationToken ct = default);
+    Task<HttpResult<CallResult<OKXOrderPlaceResponse>[]>> PlaceMultipleOrdersAsync(IEnumerable<OKXOrderPlaceRequest> orders, CancellationToken ct = default);
 
     /// <summary>
     /// Place a new order
@@ -455,7 +455,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="maxSlippagePercentage">["<c>maxSlippagePercentage</c>"] Maximum acceptable slippage for spot and spot margin market-side orders, ranged 0 to 0.05</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXOrderPlaceResponse>> PlaceOrderAsync(
+    Task<HttpResult<OKXOrderPlaceResponse>> PlaceOrderAsync(
         string symbol,
         OrderSide side,
         OrderType type,
@@ -507,7 +507,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="quantityAsset">["<c>tgtCcy</c>"] Asset of the quantity when placing market order</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXCheckOrderResponse>> CheckOrderAsync(
+    Task<HttpResult<OKXCheckOrderResponse>> CheckOrderAsync(
         string symbol,
         OrderSide side,
         OrderType type,
@@ -538,7 +538,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="clientAlgoId">["<c>algoClOrdId</c>"] Client algo order id, this or algoId should be provided</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAlgoOrder>> GetAlgoOrderAsync(string? algoId = null, string? clientAlgoId = null, CancellationToken ct = default);
+    Task<HttpResult<OKXAlgoOrder>> GetAlgoOrderAsync(string? algoId = null, string? clientAlgoId = null, CancellationToken ct = default);
 
     /// <summary>
     /// Edit an incomplete algo order.
@@ -563,7 +563,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="newStopLossPriceTriggerType">["<c>newSlTriggerPxType</c>"] New stop loss price trigger type</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAlgoOrderAmendResponse>> AmendAlgoOrderAsync(
+    Task<HttpResult<OKXAlgoOrderAmendResponse>> AmendAlgoOrderAsync(
         string symbol,
         string? algoId = null,
         string? clientAlgoId = null,
@@ -589,7 +589,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// </summary>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXAccountRateLimit[]>> GetAccountRateLimitAsync(CancellationToken ct = default);
+    Task<HttpResult<OKXAccountRateLimit[]>> GetAccountRateLimitAsync(CancellationToken ct = default);
 
     /// <summary>
     /// Get list of debt currency data and repay currencies.
@@ -603,7 +603,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="debtType">["<c>debtType</c>"] Debt type (cross/isolated)</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXOneClickRepayCurrencyList[]>> GetOneClickRepayCurrencyListAsync(string? debtType = null, CancellationToken ct = default);
+    Task<HttpResult<OKXOneClickRepayCurrencyList[]>> GetOneClickRepayCurrencyListAsync(string? debtType = null, CancellationToken ct = default);
 
     /// <summary>
     /// Get list of debt currency data and repay currencies.
@@ -616,7 +616,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// </summary>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXOneClickRepayCurrencyListV2[]>> GetOneClickRepayCurrencyListV2Async(CancellationToken ct = default);
+    Task<HttpResult<OKXOneClickRepayCurrencyListV2[]>> GetOneClickRepayCurrencyListV2Async(CancellationToken ct = default);
 
     /// <summary>
     /// Trade one-click repay to repay cross debts.
@@ -631,7 +631,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="repayAsset">["<c>repayCcy</c>"] Repay currency</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXOneClickRepayResponse[]>> OneClickRepayAsync(string debtAsset, string repayAsset, CancellationToken ct = default);
+    Task<HttpResult<OKXOneClickRepayResponse[]>> OneClickRepayAsync(string debtAsset, string repayAsset, CancellationToken ct = default);
 
     /// <summary>
     /// Trade one-click repay to repay debts.
@@ -646,7 +646,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="repayAssetList">["<c>repayCcyList</c>"] Repay currency list</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXOneClickRepayResponseV2[]>> OneClickRepayV2Async(string debtAsset, IEnumerable<string> repayAssetList, CancellationToken ct = default);
+    Task<HttpResult<OKXOneClickRepayResponseV2[]>> OneClickRepayV2Async(string debtAsset, IEnumerable<string> repayAssetList, CancellationToken ct = default);
 
     /// <summary>
     /// Get the history and status of one-click repay trades in the past 7 days.
@@ -662,7 +662,7 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="limit">["<c>limit</c>"] Number of results per request</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXOneClickRepayHistory[]>> GetOneClickRepayHistoryAsync(DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
+    Task<HttpResult<OKXOneClickRepayHistory[]>> GetOneClickRepayHistoryAsync(DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
 
     /// <summary>
     /// Get the history and status of one-click repay trades in the past 7 days.
@@ -678,6 +678,6 @@ public interface IOKXRestClientUnifiedApiTrading
     /// <param name="limit">["<c>limit</c>"] Number of results per request</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<WebCallResult<OKXOneClickRepayHistoryV2[]>> GetOneClickRepayHistoryV2Async(DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
+    Task<HttpResult<OKXOneClickRepayHistoryV2[]>> GetOneClickRepayHistoryV2Async(DateTime? startTime = null, DateTime? endTime = null, int limit = 100, CancellationToken ct = default);
 }
 

--- a/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXSocketClientUnifiedApiAccount.cs
+++ b/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXSocketClientUnifiedApiAccount.cs
@@ -23,7 +23,7 @@ public interface IOKXSocketClientUnifiedApiAccount
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToAccountUpdatesAsync(string? asset, bool regularUpdates, Action<DataEvent<OKXAccountBalance>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToAccountUpdatesAsync(string? asset, bool regularUpdates, Action<DataEvent<OKXAccountBalance>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to account balance and position information updates. Data will be pushed when triggered by events such as filled order, funding transfer.
@@ -37,7 +37,7 @@ public interface IOKXSocketClientUnifiedApiAccount
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToBalanceAndPositionUpdatesAsync(Action<DataEvent<OKXPositionAndBalanceUpdate>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToBalanceAndPositionUpdatesAsync(Action<DataEvent<OKXPositionAndBalanceUpdate>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to deposit updates
@@ -51,7 +51,7 @@ public interface IOKXSocketClientUnifiedApiAccount
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToDepositUpdatesAsync(Action<DataEvent<OKXDepositUpdate>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToDepositUpdatesAsync(Action<DataEvent<OKXDepositUpdate>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to withdrawal updates
@@ -65,7 +65,7 @@ public interface IOKXSocketClientUnifiedApiAccount
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToWithdrawalUpdatesAsync(Action<DataEvent<OKXWithdrawalUpdate>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToWithdrawalUpdatesAsync(Action<DataEvent<OKXWithdrawalUpdate>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to account greeks updates
@@ -79,7 +79,7 @@ public interface IOKXSocketClientUnifiedApiAccount
     /// <param name="asset">Asset filter</param>
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
-    Task<CallResult<UpdateSubscription>> SubscribeToGreeksUpdatesAsync(
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToGreeksUpdatesAsync(
         string? asset,
         Action<DataEvent<OKXGreeks[]>> onData,
         CancellationToken ct = default);

--- a/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXSocketClientUnifiedApiExchangeData.cs
+++ b/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXSocketClientUnifiedApiExchangeData.cs
@@ -27,7 +27,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToEstimatedPriceUpdatesAsync(InstrumentType instrumentType, string? instrumentFamily, string? symbol, Action<DataEvent<OKXEstimatedPrice>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToEstimatedPriceUpdatesAsync(InstrumentType instrumentType, string? instrumentFamily, string? symbol, Action<DataEvent<OKXEstimatedPrice>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to funding rate updates. Data will be pushed every minute.
@@ -42,7 +42,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToFundingRateUpdatesAsync(string symbol, Action<DataEvent<OKXFundingRate>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToFundingRateUpdatesAsync(string symbol, Action<DataEvent<OKXFundingRate>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to funding rate updates. Data will be pushed every minute.
@@ -57,7 +57,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToFundingRateUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXFundingRate>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToFundingRateUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXFundingRate>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to the index klime/candlesticks updates. Data will be pushed every 500 ms.
@@ -73,7 +73,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToIndexKlineUpdatesAsync(string symbol, KlineInterval period, Action<DataEvent<OKXMiniKline[]>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToIndexKlineUpdatesAsync(string symbol, KlineInterval period, Action<DataEvent<OKXMiniKline[]>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to index tickers data updates
@@ -88,7 +88,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToIndexTickerUpdatesAsync(string symbol, Action<DataEvent<OKXIndexTicker>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToIndexTickerUpdatesAsync(string symbol, Action<DataEvent<OKXIndexTicker>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to index tickers data updates
@@ -103,7 +103,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToIndexTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXIndexTicker>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToIndexTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXIndexTicker>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to the open interest updates. Data will by pushed every 3 seconds.
@@ -118,7 +118,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToOpenInterestUpdatesAsync(string symbol, Action<DataEvent<OKXOpenInterest>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToOpenInterestUpdatesAsync(string symbol, Action<DataEvent<OKXOpenInterest>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to the open interest updates. Data will by pushed every 3 seconds.
@@ -133,7 +133,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToOpenInterestUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXOpenInterest>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToOpenInterestUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXOpenInterest>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to kline/candlesticks updates of a symbol. Data will be pushed every 500 ms.
@@ -149,7 +149,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval period, Action<DataEvent<OKXKline>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval period, Action<DataEvent<OKXKline>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to kline/candlesticks updates of multiple symbols. Data will be pushed every 500 ms.
@@ -165,7 +165,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols, KlineInterval period, Action<DataEvent<OKXKline>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(IEnumerable<string> symbols, KlineInterval period, Action<DataEvent<OKXKline>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to the mark price updates. Data will be pushed every 200 ms when the mark price changes, and will be pushed every 10 seconds when the mark price does not change.
@@ -180,7 +180,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToMarkPriceUpdatesAsync(string symbol, Action<DataEvent<OKXMarkPrice>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToMarkPriceUpdatesAsync(string symbol, Action<DataEvent<OKXMarkPrice>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to the mark price updates. Data will be pushed every 200 ms when the mark price changes, and will be pushed every 10 seconds when the mark price does not change.
@@ -195,7 +195,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToMarkPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXMarkPrice>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToMarkPriceUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXMarkPrice>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to mark price kline/candlesticks updates. Data will be pushed every 500 ms.
@@ -211,7 +211,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToMarkPriceKlineUpdatesAsync(string symbol, KlineInterval period, Action<DataEvent<OKXMiniKline[]>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToMarkPriceKlineUpdatesAsync(string symbol, KlineInterval period, Action<DataEvent<OKXMiniKline[]>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to detailed pricing information updates of all OPTION contracts. Data will be pushed at once.
@@ -226,7 +226,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToOptionSummaryUpdatesAsync(string instrumentFamily, Action<DataEvent<OKXOptionSummary[]>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToOptionSummaryUpdatesAsync(string instrumentFamily, Action<DataEvent<OKXOptionSummary[]>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to order book data updates.<br />
@@ -247,7 +247,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, OrderBookType orderBookType, Action<DataEvent<OKXOrderBook>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, OrderBookType orderBookType, Action<DataEvent<OKXOrderBook>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to order book data updates.<br />
@@ -268,7 +268,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, OrderBookType orderBookType, Action<DataEvent<OKXOrderBook>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(IEnumerable<string> symbols, OrderBookType orderBookType, Action<DataEvent<OKXOrderBook>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to the maximum buy price and minimum sell price of the instrument updates. Data will be pushed every 5 seconds when there are changes in limits, and will not be pushed when there is no changes on limit.
@@ -283,7 +283,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToPriceLimitUpdatesAsync(string symbol, Action<DataEvent<OKXLimitPrice>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToPriceLimitUpdatesAsync(string symbol, Action<DataEvent<OKXLimitPrice>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to the maximum buy price and minimum sell price of the instrument updates. Data will be pushed every 5 seconds when there are changes in limits, and will not be pushed when there is no changes on limit.
@@ -298,7 +298,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToPriceLimitUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXLimitPrice>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToPriceLimitUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXLimitPrice>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to symbols updates. The instruments will be pushed if there's any change to the instrument’s state (such as delivery of FUTURES, exercise of OPTION, listing of new contracts / trading pairs, trading suspension, etc.).
@@ -313,7 +313,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(InstrumentType instrumentType, Action<DataEvent<OKXInstrument[]>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToSymbolUpdatesAsync(InstrumentType instrumentType, Action<DataEvent<OKXInstrument[]>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to status updates of system maintenance and push when the system maintenance status changes. First subscription: "Push the latest change data"; every time there is a state change, push the changed content
@@ -327,7 +327,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToSystemStatusUpdatesAsync(Action<DataEvent<OKXStatus>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToSystemStatusUpdatesAsync(Action<DataEvent<OKXStatus>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to the last traded price updates, bid price, ask price and 24-hour trading volume of instruments. Data will be pushed every 100 ms.
@@ -342,7 +342,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(string symbol, Action<DataEvent<OKXTicker>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(string symbol, Action<DataEvent<OKXTicker>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to the last traded price updates, bid price, ask price and 24-hour trading volume of instruments. Data will be pushed every 100 ms.
@@ -357,7 +357,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXTicker>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXTicker>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to the recent trades data updates. Data will be pushed whenever there is a trade.
@@ -372,7 +372,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<OKXTrade>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<OKXTrade>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to the recent trades data updates. Data will be pushed whenever there is a trade.
@@ -387,7 +387,7 @@ public interface IOKXSocketClientUnifiedApiExchangeData
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXTrade>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<OKXTrade>> onData, CancellationToken ct = default);
 
 }
 

--- a/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXSocketClientUnifiedApiTrading.cs
+++ b/OKX.Net/Interfaces/Clients/UnifiedApi/IOKXSocketClientUnifiedApiTrading.cs
@@ -25,7 +25,7 @@ public interface IOKXSocketClientUnifiedApiTrading
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToAdvanceAlgoOrderUpdatesAsync(InstrumentType instrumentType, string? symbol, string? algoId, Action<DataEvent<OKXAlgoOrderUpdate>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToAdvanceAlgoOrderUpdatesAsync(InstrumentType instrumentType, string? symbol, string? algoId, Action<DataEvent<OKXAlgoOrderUpdate>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to algo orders (includes trigger order, oco order, conditional order) updates. Data will not be pushed when first subscribed. Data will only be pushed when triggered by events such as placing/canceling order.
@@ -42,7 +42,7 @@ public interface IOKXSocketClientUnifiedApiTrading
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToAlgoOrderUpdatesAsync(InstrumentType instrumentType, string? symbol, string? instrumentFamily, Action<DataEvent<OKXAlgoOrderUpdate>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToAlgoOrderUpdatesAsync(InstrumentType instrumentType, string? symbol, string? instrumentFamily, Action<DataEvent<OKXAlgoOrderUpdate>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to order information updates. Data will not be pushed when first subscribed. Data will only be pushed when triggered by events such as placing/canceling order.
@@ -59,7 +59,7 @@ public interface IOKXSocketClientUnifiedApiTrading
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(InstrumentType instrumentType, string? symbol, string? instrumentFamily, Action<DataEvent<OKXOrderUpdate>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToOrderUpdatesAsync(InstrumentType instrumentType, string? symbol, string? instrumentFamily, Action<DataEvent<OKXOrderUpdate>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// Subscribe to user trade updates. Note that this subscription is only available to VIP5 accounts or above.
@@ -74,7 +74,7 @@ public interface IOKXSocketClientUnifiedApiTrading
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToUserTradeUpdatesAsync(
         string? symbol,
         Action<DataEvent<OKXUserTradeUpdate>> onData,
         CancellationToken ct = default);
@@ -95,7 +95,7 @@ public interface IOKXSocketClientUnifiedApiTrading
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(InstrumentType instrumentType, string? symbol, string? instrumentFamily, bool regularUpdates, Action<DataEvent<OKXPosition[]>> onData, CancellationToken ct = default);
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToPositionUpdatesAsync(InstrumentType instrumentType, string? symbol, string? instrumentFamily, bool regularUpdates, Action<DataEvent<OKXPosition[]>> onData, CancellationToken ct = default);
 
     /// <summary>
     /// This push channel is only used as a risk warning, and is not recommended as a risk judgment for strategic trading. In the case that the market is volatile, there may be the possibility that the position has been liquidated at the same time that this message is pushed. The warning is sent when a position is at risk of liquidation for isolated margin positions.The warning is sent when all the positions are at risk of liquidation for cross margin positions.
@@ -111,7 +111,7 @@ public interface IOKXSocketClientUnifiedApiTrading
     /// <param name="onData">On Data Handler</param>
     /// <param name="ct">Cancellation Token</param>
     /// <returns></returns>
-    Task<CallResult<UpdateSubscription>> SubscribeToLiquidationWarningUpdatesAsync(InstrumentType instrumentType,
+    Task<WebSocketResult<UpdateSubscription>> SubscribeToLiquidationWarningUpdatesAsync(InstrumentType instrumentType,
         string? instrumentFamily,
         Action<DataEvent<OKXPosition>> onData,
         CancellationToken ct = default);
@@ -143,7 +143,7 @@ public interface IOKXSocketClientUnifiedApiTrading
     /// <param name="maxSlippagePercentage">["<c>maxSlippagePercentage</c>"] Maximum acceptable slippage for spot and spot margin market-side orders, ranged 0 to 0.05</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns></returns>
-    Task<CallResult<OKXOrderPlaceResponse>> PlaceOrderAsync(
+    Task<QueryResult<OKXOrderPlaceResponse>> PlaceOrderAsync(
         long symbolCode,
         OrderSide side,
         OrderType type,
@@ -176,7 +176,7 @@ public interface IOKXSocketClientUnifiedApiTrading
     /// <param name="orders">The orders to place</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns></returns>
-    Task<CallResult<CallResult<OKXOrderPlaceResponse>[]>> PlaceMultipleOrdersAsync(IEnumerable<OKXOrderPlaceRequest> orders, CancellationToken ct = default);
+    Task<QueryResult<CallResult<OKXOrderPlaceResponse>[]>> PlaceMultipleOrdersAsync(IEnumerable<OKXOrderPlaceRequest> orders, CancellationToken ct = default);
 
     /// <summary>
     /// Cancel an incomplete order
@@ -192,7 +192,7 @@ public interface IOKXSocketClientUnifiedApiTrading
     /// <param name="clientOrderId">Cancel by client order id. This or orderId should be provided</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns></returns>
-    Task<CallResult<OKXOrderCancelResponse>> CancelOrderAsync(long symbolCode, string? orderId = null, string? clientOrderId = null, CancellationToken ct = default);
+    Task<QueryResult<OKXOrderCancelResponse>> CancelOrderAsync(long symbolCode, string? orderId = null, string? clientOrderId = null, CancellationToken ct = default);
 
     /// <summary>
     /// Cancel incomplete orders in batches. Maximum 20 orders can be canceled per request.
@@ -206,7 +206,7 @@ public interface IOKXSocketClientUnifiedApiTrading
     /// <param name="ordersToCancel">Orders to cancel</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns></returns>
-    Task<CallResult<OKXOrderCancelResponse[]>> CancelMultipleOrdersAsync(IEnumerable<OKXOrderCancelSocketRequest> ordersToCancel, CancellationToken ct = default);
+    Task<QueryResult<OKXOrderCancelResponse[]>> CancelMultipleOrdersAsync(IEnumerable<OKXOrderCancelSocketRequest> ordersToCancel, CancellationToken ct = default);
 
     /// <summary>
     /// Edit an incomplete order.
@@ -225,7 +225,7 @@ public interface IOKXSocketClientUnifiedApiTrading
     /// <param name="newPrice">New price</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns></returns>
-    Task<CallResult<OKXOrderAmendResponse>> AmendOrderAsync(
+    Task<QueryResult<OKXOrderAmendResponse>> AmendOrderAsync(
         long symbolCode,
         long? orderId = null,
         string? clientOrderId = null,
@@ -246,7 +246,7 @@ public interface IOKXSocketClientUnifiedApiTrading
     /// <param name="ordersToCancel">Orders to cancel</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns></returns>
-    Task<CallResult<OKXOrderAmendResponse[]>> AmendMultipleOrdersAsync(IEnumerable<OKXOrderAmendRequest> ordersToCancel, CancellationToken ct = default);
+    Task<QueryResult<OKXOrderAmendResponse[]>> AmendMultipleOrdersAsync(IEnumerable<OKXOrderAmendRequest> ordersToCancel, CancellationToken ct = default);
 }
 
 

--- a/OKX.Net/OKX.Net.csproj
+++ b/OKX.Net/OKX.Net.csproj
@@ -54,12 +54,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CryptoExchange.Net" Version="12.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/OKX.Net/OKX.Net.csproj
+++ b/OKX.Net/OKX.Net.csproj
@@ -58,6 +58,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CryptoExchange.Net" Version="11.2.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/OKX.Net/OKXAuthenticationProvider.cs
+++ b/OKX.Net/OKXAuthenticationProvider.cs
@@ -24,7 +24,7 @@ internal class OKXAuthenticationProvider : AuthenticationProvider<OKXCredentials
         var queryString = request.GetQueryString(true);
         if (!string.IsNullOrEmpty(queryString))
             queryString = $"?{queryString}";
-        var body = request.ParameterPosition == HttpMethodParameterPosition.InBody ? request.BodyParameters?.Count > 0 ? GetSerializedBody(_serializer, request.BodyParameters) : "{}" : string.Empty;
+        var body = request.ParameterPosition == HttpMethodParameterPosition.InBody ? (request.BodyParameters != null && !request.BodyParameters.Empty) ? GetSerializedBody(_serializer, request.BodyParameters) : "{}" : string.Empty;
         var signStr = time + request.RequestDefinition.Method + request.RequestDefinition.Path + queryString + body;
 
         var signature = SignHMACSHA256(signStr, SignOutputType.Base64);

--- a/OKX.Net/OKXAuthenticationProvider.cs
+++ b/OKX.Net/OKXAuthenticationProvider.cs
@@ -17,7 +17,7 @@ internal class OKXAuthenticationProvider : AuthenticationProvider<OKXCredentials
 
     public override void ProcessRequest(RestApiClient apiClient, RestRequestConfiguration request)
     {
-        if (!request.Authenticated && !((OKXRestOptions)apiClient.ClientOptions).SignPublicRequests)
+        if (!request.RequestDefinition.Authenticated && !((OKXRestOptions)apiClient.ClientOptions).SignPublicRequests)
             return;
 
         var time = GetTimestamp(apiClient).ToString("yyyy-MM-ddTHH:mm:ss.sssZ");
@@ -25,7 +25,7 @@ internal class OKXAuthenticationProvider : AuthenticationProvider<OKXCredentials
         if (!string.IsNullOrEmpty(queryString))
             queryString = $"?{queryString}";
         var body = request.ParameterPosition == HttpMethodParameterPosition.InBody ? request.BodyParameters?.Count > 0 ? GetSerializedBody(_serializer, request.BodyParameters) : "{}" : string.Empty;
-        var signStr = time + request.Method + request.Path + queryString + body;
+        var signStr = time + request.RequestDefinition.Method + request.RequestDefinition.Path + queryString + body;
 
         var signature = SignHMACSHA256(signStr, SignOutputType.Base64);
         request.Headers ??= new Dictionary<string, string>();

--- a/OKX.Net/OKXExchange.cs
+++ b/OKX.Net/OKXExchange.cs
@@ -56,6 +56,12 @@ namespace OKX.Net
         public static ExchangeType Type { get; } = ExchangeType.CEX;
 
         internal static JsonSerializerContext _serializerContext = JsonSerializerContextCache.GetOrCreate<OKXSourceGenerationContext>();
+        internal static ParameterSerializationSettings _parameterSerializationSettings = new ParameterSerializationSettings()
+        {
+            DateTimes = DateTimeSerialization.MillisecondsString,
+            Decimal = DecimalSerialization.String,
+            Integer = IntegerSerialization.String
+        };  
 
         /// <summary>
         /// Aliases for OKX assets

--- a/OKX.Net/OKXExchange.cs
+++ b/OKX.Net/OKXExchange.cs
@@ -99,7 +99,7 @@ namespace OKX.Net
         /// <summary>
         /// Rate limiter configuration for the OKX API
         /// </summary>
-        public static OKXRateLimiters RateLimiter { get; } = new OKXRateLimiters();
+        public static OKXRateLimiters RateLimiter { get; set; } = new OKXRateLimiters();
     }
 
     /// <summary>
@@ -118,13 +118,19 @@ namespace OKX.Net
         public event Action<RateLimitUpdateEvent> RateLimitUpdated;
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        internal OKXRateLimiters()
+        /// <summary>
+        /// ctor
+        /// </summary>
+        public OKXRateLimiters()
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
             Initialize();
         }
 
-        private void Initialize()
+        /// <summary>
+        /// Initialize the rate limits
+        /// </summary>
+        protected virtual void Initialize()
         {
             EndpointGate = new RateLimitGate("Endpoint Gate");
             EndpointGate.RateLimitTriggered += (x) => RateLimitTriggered?.Invoke(x);

--- a/OKX.Net/OKXExchange.cs
+++ b/OKX.Net/OKXExchange.cs
@@ -20,7 +20,8 @@ namespace OKX.Net
                 "https://www.okx.com",
                 ["https://www.okx.com/docs-v5/en/"],
                 PlatformType.CryptoCurrencyExchange,
-                CentralizationType.Centralized
+                CentralizationType.Centralized,
+                OKXEnvironment.All
                 );
 
         /// <summary>
@@ -75,6 +76,18 @@ namespace OKX.Net
         };
 
         /// <summary>
+        /// Aliases for OKX assets in the Europe environment
+        /// </summary>
+        public static AssetAliasConfiguration AssetAliasesFuturesEurope { get; } = new AssetAliasConfiguration
+        {
+            Aliases =
+            [
+                new AssetAlias("USD", SharedSymbol.UsdOrStable.ToUpperInvariant(), AliasType.OnlyToExchange)
+            ]
+        };
+
+
+        /// <summary>
         /// Format a base and quote asset to an OKX recognized symbol 
         /// </summary>
         /// <param name="baseAsset">Base asset</param>
@@ -94,6 +107,36 @@ namespace OKX.Net
                 return baseAsset + "-" + quoteAsset + "-SWAP";
 
             return baseAsset + "-" + quoteAsset + "-" + deliverTime.Value.ToString("yyMMdd");
+        }
+
+        /// <summary>
+        /// Format a base and quote asset to an OKX recognized symbol for the Europe environment
+        /// </summary>
+        /// <param name="baseAsset">Base asset</param>
+        /// <param name="quoteAsset">Quote asset</param>
+        /// <param name="tradingMode">Trading mode</param>
+        /// <param name="deliverTime">Delivery time for delivery futures</param>
+        /// <returns></returns>
+        public static string FormatSymbolEurope(string baseAsset, string quoteAsset, TradingMode tradingMode, DateTime? deliverTime)
+        {
+            if (tradingMode == TradingMode.Spot)
+            {
+                baseAsset = AssetAliases.CommonToExchangeName(baseAsset.ToUpperInvariant());
+                quoteAsset = AssetAliases.CommonToExchangeName(quoteAsset.ToUpperInvariant());
+                return baseAsset + "-" + quoteAsset;
+            }
+
+            baseAsset = AssetAliasesFuturesEurope.CommonToExchangeName(baseAsset.ToUpperInvariant());
+            quoteAsset = AssetAliasesFuturesEurope.CommonToExchangeName(quoteAsset.ToUpperInvariant());
+            var symbols = ExchangeSymbolCache.GetSymbolsForBaseAsset("OKXFutures", "Europe", tradingMode.ToString(), baseAsset);
+            if (symbols.Length == 1 && symbols[0].SymbolName != null)
+                return symbols[0].SymbolName!;
+
+            // Fallback
+            if (deliverTime == null)
+                return baseAsset + "-" + quoteAsset + "-SWAP";
+            else
+                return baseAsset + "-" + quoteAsset + $"_UM_{deliverTime:yyMMdd}";
         }
 
         /// <summary>

--- a/OKX.Net/OKXUserDataTracker.cs
+++ b/OKX.Net/OKXUserDataTracker.cs
@@ -20,7 +20,6 @@ namespace OKX.Net
             SpotUserDataTrackerConfig? config) : base(
                 logger,
                 restClient.UnifiedApi.SharedClient,
-                null,
                 restClient.UnifiedApi.SharedClient,
                 socketClient.UnifiedApi.SharedClient,
                 restClient.UnifiedApi.SharedClient,
@@ -48,7 +47,6 @@ namespace OKX.Net
             string? userIdentifier,
             FuturesUserDataTrackerConfig? config) : base(logger,
                 restClient.UnifiedApi.SharedClient,
-                null,
                 restClient.UnifiedApi.SharedClient,
                 socketClient.UnifiedApi.SharedClient,
                 restClient.UnifiedApi.SharedClient,

--- a/OKX.Net/Objects/Options/OKXOptions.cs
+++ b/OKX.Net/Objects/Options/OKXOptions.cs
@@ -6,4 +6,8 @@ namespace OKX.Net.Objects.Options;
 /// </summary>
 public class OKXOptions : LibraryOptions<OKXRestOptions, OKXSocketOptions, OKXCredentials, OKXEnvironment>
 {
+    /// <summary>
+    /// Whether to use XPerps as perpetual linear contracts when using the Shared API's
+    /// </summary>
+    public bool SharedApiEuropeUseXPerps { get; set; }
 }

--- a/OKX.Net/Objects/Options/OKXRestOptions.cs
+++ b/OKX.Net/Objects/Options/OKXRestOptions.cs
@@ -34,6 +34,11 @@ public class OKXRestOptions : RestExchangeOptions<OKXEnvironment, OKXCredentials
     public string? BrokerId { get; set; }
 
     /// <summary>
+    /// Whether to use XPerps as perpetual linear contracts when using the Shared API's
+    /// </summary>
+    public bool SharedApiEuropeUseXPerps { get; set; }
+
+    /// <summary>
     /// Options for the  unified API
     /// </summary>
     public RestApiOptions UnifiedOptions { get; private set; } = new RestApiOptions();
@@ -44,6 +49,7 @@ public class OKXRestOptions : RestExchangeOptions<OKXEnvironment, OKXCredentials
         targetOptions.SignPublicRequests = SignPublicRequests;
         targetOptions.BrokerId = BrokerId;
         targetOptions.UnifiedOptions = UnifiedOptions.Set(targetOptions.UnifiedOptions);
+        targetOptions.SharedApiEuropeUseXPerps = SharedApiEuropeUseXPerps;
         return targetOptions;
     }
 }

--- a/OKX.Net/Objects/Options/OKXSocketOptions.cs
+++ b/OKX.Net/Objects/Options/OKXSocketOptions.cs
@@ -30,6 +30,11 @@ public class OKXSocketOptions : SocketExchangeOptions<OKXEnvironment, OKXCredent
     public string? BrokerId { get; set; }
 
     /// <summary>
+    /// Whether to use XPerps as perpetual linear contracts when using the Shared API's
+    /// </summary>
+    public bool SharedApiEuropeUseXPerps { get; set; }
+
+    /// <summary>
     /// Options for the Unified API
     /// </summary>
     public SocketApiOptions UnifiedOptions { get; private set; } = new SocketApiOptions();
@@ -39,6 +44,7 @@ public class OKXSocketOptions : SocketExchangeOptions<OKXEnvironment, OKXCredent
         targetOptions = base.Set<OKXSocketOptions>(targetOptions);
         targetOptions.BrokerId = BrokerId;
         targetOptions.UnifiedOptions = UnifiedOptions.Set(targetOptions.UnifiedOptions);
+        targetOptions.SharedApiEuropeUseXPerps = SharedApiEuropeUseXPerps;
         return targetOptions;
     }
 }

--- a/OKX.Net/Objects/Sockets/Queries/OKXIdQuery.cs
+++ b/OKX.Net/Objects/Sockets/Queries/OKXIdQuery.cs
@@ -12,14 +12,14 @@ internal class OKXIdQuery<T> : Query<OKXSocketResponse<T[]>>
     public OKXIdQuery(SocketApiClient client, string op, object[] args, bool authenticated, int weight = 1) : base(new OKXSocketIdRequest() { Id = ExchangeHelpers.NextId().ToString(), Op = op, Args = args }, authenticated, weight)
     {
         _client = client;
-        MessageRouter = MessageRouter.CreateWithoutTopicFilter<OKXSocketResponse<T[]>>(((OKXSocketIdRequest)Request).Id, HandleMessage);
+        MessageRouter = MessageRouter.CreateForQuery<OKXSocketResponse<T[]>>(((OKXSocketIdRequest)Request).Id, HandleMessage);
     }
 
     public CallResult<OKXSocketResponse<T[]>> HandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, OKXSocketResponse<T[]> message)
     {
         if (string.Equals(message.Event, "error", StringComparison.Ordinal))
-            return new CallResult<OKXSocketResponse<T[]>>(new ServerError(message.Code!.Value, _client.GetErrorInfo(message.Code.Value, message.Message!)), originalData);
+            return CallResult<OKXSocketResponse<T[]>>.Fail(new ServerError(message.Code!.Value, _client.GetErrorInfo(message.Code.Value, message.Message!)), originalData);
 
-        return new CallResult<OKXSocketResponse<T[]>>(message, originalData, null);
+        return CallResult<OKXSocketResponse<T[]>>.Ok(message, originalData);
     }
 }

--- a/OKX.Net/Objects/Sockets/Queries/OKXPingQuery.cs
+++ b/OKX.Net/Objects/Sockets/Queries/OKXPingQuery.cs
@@ -7,6 +7,6 @@ internal class OKXPingQuery : Query<string>
     public OKXPingQuery() : base("ping", false, 0)
     {
         RequestTimeout = TimeSpan.FromSeconds(5);
-        MessageRouter = MessageRouter.CreateWithoutHandler<string>("pong");
+        MessageRouter = MessageRouter.CreateVoid<string>("pong");
     }
 }

--- a/OKX.Net/Objects/Sockets/Queries/OKXQuery.cs
+++ b/OKX.Net/Objects/Sockets/Queries/OKXQuery.cs
@@ -17,8 +17,8 @@ internal class OKXQuery : Query<OKXSocketResponse>
         foreach (var arg in request.Args)
         {
             var topic = arg.InstrumentType + arg.InstrumentFamily + arg.Symbol;
-            routes.Add(MessageRoute<OKXSocketResponse>.CreateWithOptionalTopicFilter(request.Op + arg.Channel, string.IsNullOrEmpty(topic) ? null : topic, HandleMessage));
-            routes.Add(MessageRoute<OKXSocketResponse>.CreateWithoutTopicFilter("error" + arg.Channel + topic, HandleMessage));
+            routes.Add(MessageRoute.CreateForQuery<OKXSocketResponse>(request.Op + arg.Channel, string.IsNullOrEmpty(topic) ? null : topic, HandleMessage));
+            routes.Add(MessageRoute.CreateForQuery<OKXSocketResponse>("error" + arg.Channel + topic, HandleMessage));
         }
 
         MessageRouter = MessageRouter.Create(routes.ToArray());
@@ -29,14 +29,14 @@ internal class OKXQuery : Query<OKXSocketResponse>
     public OKXQuery(SocketApiClient client, OKXSocketAuthRequest request, bool authenticated, int weight = 1) : base(request, authenticated, weight)
     {
         _client = client;
-        MessageRouter = MessageRouter.CreateWithoutTopicFilter<OKXSocketResponse>(["login", "error"], HandleMessage);
+        MessageRouter = MessageRouter.CreateForQuery<OKXSocketResponse>(["login", "error"], HandleMessage);
     }
 
     public CallResult<OKXSocketResponse> HandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, OKXSocketResponse message)
     {
         if (string.Equals(message.Event, "error", StringComparison.Ordinal))
-            return new CallResult<OKXSocketResponse>(new ServerError(message.Code!.Value, _client.GetErrorInfo(message.Code.Value, message.Message!)), originalData);
+            return CallResult<OKXSocketResponse>.Fail(new ServerError(message.Code!.Value, _client.GetErrorInfo(message.Code.Value, message.Message!)), originalData);
 
-        return new CallResult<OKXSocketResponse>(message, originalData, null);
+        return CallResult<OKXSocketResponse>.Ok(message, originalData);
     }
 }

--- a/OKX.Net/Objects/Sockets/Subscriptions/OKXBookSubscription.cs
+++ b/OKX.Net/Objects/Sockets/Subscriptions/OKXBookSubscription.cs
@@ -23,7 +23,7 @@ internal class OKXBookSubscription : Subscription
 
         IndividualSubscriptionCount = args.Count;
 
-        MessageRouter = MessageRouter.CreateWithTopicFilters<OKXSocketUpdate<OKXOrderBook[]>>(args.First().Channel, args.Select(x => x.InstrumentType + x.InstrumentFamily + x.Symbol), DoHandleMessage);
+        MessageRouter = MessageRouter.CreateForEvent<OKXSocketUpdate<OKXOrderBook[]>>(args.First().Channel, args.Select(x => x.InstrumentType + x.InstrumentFamily + x.Symbol), DoHandleMessage);
     }
 
     protected override Query? GetSubQuery(SocketConnection connection)
@@ -60,6 +60,6 @@ internal class OKXBookSubscription : Subscription
                     .WithSequenceNumber(book.SequenceId)
                     .WithUpdateType(string.Equals(message.Action, "snapshot", StringComparison.Ordinal) || message.Action == null ? SocketUpdateType.Snapshot : SocketUpdateType.Update)
             );
-        return CallResult.SuccessResult;
+        return CallResult.Ok();
     }
 }

--- a/OKX.Net/Objects/Sockets/Subscriptions/OKXConnCountSubscription.cs
+++ b/OKX.Net/Objects/Sockets/Subscriptions/OKXConnCountSubscription.cs
@@ -7,6 +7,6 @@ internal class OKXConnCountSubscription : SystemSubscription
 {
     public OKXConnCountSubscription(ILogger logger) : base(logger, false)
     {
-        MessageRouter = MessageRouter.CreateWithoutHandler<OKXConnectionCount>("channel-conn-count");
+        MessageRouter = MessageRouter.CreateVoid<OKXConnectionCount>("channel-conn-count");
     }
 }

--- a/OKX.Net/Objects/Sockets/Subscriptions/OKXSubscription.cs
+++ b/OKX.Net/Objects/Sockets/Subscriptions/OKXSubscription.cs
@@ -19,7 +19,11 @@ internal class OKXSubscription<T> : Subscription
 
         IndividualSubscriptionCount = args.Count;
 
-        MessageRouter = MessageRouter.CreateWithOptionalTopicFilters<OKXSocketUpdate<T>>(args.First().Channel, GetTopicFilters(args), DoHandleMessage);
+        var topicFilters = GetTopicFilters(args);
+        if (topicFilters != null)
+            MessageRouter = MessageRouter.CreateForEvent<OKXSocketUpdate<T>>(args.First().Channel, topicFilters, DoHandleMessage);
+        else
+            MessageRouter = MessageRouter.CreateForEvent<OKXSocketUpdate<T>>(args.First().Channel, DoHandleMessage);
     }
 
     private IEnumerable<string>? GetTopicFilters(List<OKXSocketArgs> args)
@@ -52,6 +56,6 @@ internal class OKXSubscription<T> : Subscription
     public CallResult DoHandleMessage(SocketConnection connection, DateTime receiveTime, string? originalData, OKXSocketUpdate<T> message)
     {
         _handler.Invoke(receiveTime, originalData, message);
-        return CallResult.SuccessResult;
+        return CallResult.Ok();
     }
 }

--- a/OKX.Net/SymbolOrderBooks/OKXSymbolOrderBook.cs
+++ b/OKX.Net/SymbolOrderBooks/OKXSymbolOrderBook.cs
@@ -69,22 +69,22 @@ namespace OKX.Net.SymbolOrderBooks
         protected override async Task<CallResult<UpdateSubscription>> DoStartAsync(CancellationToken ct)
         {
             var result = await _socketClient.UnifiedApi.ExchangeData.SubscribeToOrderBookUpdatesAsync(Symbol, _type, ProcessUpdate).ConfigureAwait(false);
-            if (!result)
-                return result;
+            if (!result.Success)
+                return CallResult.Fail<UpdateSubscription>(result.Error);
 
             if (ct.IsCancellationRequested)
             {
                 await result.Data.CloseAsync().ConfigureAwait(false);
-                return result.AsError<UpdateSubscription>(new CancellationRequestedError());
+                return CallResult.Fail<UpdateSubscription>(new CancellationRequestedError());
             }
 
             Status = OrderBookStatus.Syncing;
 
             var setResult = await WaitForSetOrderBookAsync(_initialDataTimeout, ct).ConfigureAwait(false);
-            if (!setResult)
+            if (!setResult.Success)
                 await result.Data.CloseAsync().ConfigureAwait(false);
 
-            return setResult ? result : new CallResult<UpdateSubscription>(setResult.Error!);
+            return setResult.Success ? CallResult.Ok(result.Data) : CallResult.Fail<UpdateSubscription>(setResult.Error!);
         }
 
         /// <inheritdoc />
@@ -118,7 +118,7 @@ namespace OKX.Net.SymbolOrderBooks
         //}
 
         /// <inheritdoc />
-        protected override async Task<CallResult<bool>> DoResyncAsync(CancellationToken ct)
+        protected override async Task<CallResult> DoResyncAsync(CancellationToken ct)
         {
             return await WaitForSetOrderBookAsync(_initialDataTimeout, ct).ConfigureAwait(false);
         }

--- a/docs/ai-api-map.md
+++ b/docs/ai-api-map.md
@@ -205,12 +205,15 @@ Use this file to route common user intents to the correct OKX.Net client member.
 | Socket API amend order | `socketClient.UnifiedApi.Trading.AmendOrderAsync(...)` |
 | Socket API amend multiple orders | `socketClient.UnifiedApi.Trading.AmendMultipleOrdersAsync(...)` |
 
+WebSocket subscription methods return `WebSocketResult<UpdateSubscription>`. Socket API request/response methods return `QueryResult<T>`.
+
 ## SharedApis
 
 | User intent | OKX.Net member or interface |
 |---|---|
 | Shared REST client | `new OKXRestClient().UnifiedApi.SharedClient` |
 | Shared socket client | `new OKXSocketClient().UnifiedApi.SharedClient` |
+| Discover shared capabilities | `client.UnifiedApi.SharedClient.Discover()` |
 | Shared spot ticker REST | `ISpotTickerRestClient.GetSpotTickerAsync(new GetTickerRequest(symbol))` |
 | Shared spot order REST | `ISpotOrderRestClient.PlaceSpotOrderAsync(...)` |
 | Shared futures order REST | `IFuturesOrderRestClient.PlaceFuturesOrderAsync(...)` |
@@ -225,15 +228,19 @@ Use this file to route common user intents to the correct OKX.Net client member.
 | Shared balance socket | `IBalanceSocketClient.SubscribeToBalanceUpdatesAsync(...)` |
 | Shared position socket | `IPositionSocketClient.SubscribeToPositionUpdatesAsync(...)` |
 
+Shared REST methods return `HttpResult<T>` or `HttpResult`. Shared socket subscriptions return `WebSocketResult<UpdateSubscription>`. Shared symbol/cache helper methods can return `ExchangeCallResult<T>`.
+
 For shared socket subscriptions, keep the concrete socket client and unsubscribe with `await socketClient.UnsubscribeAsync(subscription.Data)`.
 
 ## Result Handling
 
 | Situation | Pattern |
 |---|---|
-| REST success check | `if (!result.Success) { Console.WriteLine(result.Error); return; }` |
-| Socket subscription success check | `if (!sub.Success) { Console.WriteLine(sub.Error); return; }` |
-| Read REST data | Read `result.Data` only after `result.Success` |
+| REST success check | REST methods return `HttpResult<T>` or `HttpResult`; use `if (!result.Success) { Console.WriteLine(result.Error); return; }` |
+| Socket subscription success check | Socket subscriptions return `WebSocketResult<UpdateSubscription>`; use `if (!sub.Success) { Console.WriteLine(sub.Error); return; }` |
+| Socket API request success check | Socket request/response methods return `QueryResult<T>`; use the same `.Success` and `.Error` pattern |
+| Read result data | Read `result.Data` or `sub.Data` only after `.Success` |
+| Shared helper success check | Shared symbol/cache helpers can return `ExchangeCallResult<T>`; use the same `.Success` and `.Error` pattern |
 | Retry decision | Retry only when `result.Error?.IsTransient == true` |
 | Cancellation | Pass `ct: cancellationToken` |
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -25,8 +25,8 @@ Primary documentation:
 - Include `using OKX.Net;` when using `OKXCredentials` or `OKXEnvironment`.
 - Include `using OKX.Net.Clients;` when constructing `OKXRestClient` or `OKXSocketClient`.
 - Always check `.Success` before reading `.Data`.
-- REST methods return `WebCallResult<T>` or `WebCallResult`.
-- WebSocket subscriptions and socket API requests return `CallResult<T>` or `CallResult`.
+- REST methods return `HttpResult<T>` or `HttpResult`.
+- WebSocket subscriptions and socket API requests return `WebSocketResult<T>` or `WebSocketResult`.
 - Reuse clients. Do not instantiate a REST or socket client per request in production code.
 - Prefer dependency injection for long-running services.
 - Store WebSocket subscriptions and unsubscribe during shutdown.
@@ -181,9 +181,9 @@ var price = result.Data.LastPrice;
 For retry logic, only retry transient errors:
 
 ```csharp
-async Task<WebCallResult<T>> WithRetry<T>(Func<Task<WebCallResult<T>>> call, int maxAttempts = 3)
+async Task<HttpResult<T>> WithRetry<T>(Func<Task<HttpResult<T>>> call, int maxAttempts = 3)
 {
-    WebCallResult<T> last = default!;
+    HttpResult<T> last = default!;
 
     for (var attempt = 1; attempt <= maxAttempts; attempt++)
     {
@@ -734,7 +734,7 @@ Examples/ai-friendly/04-multi-exchange.cs
   CryptoExchange.Net.SharedApis REST pattern for exchange-agnostic code.
 
 Examples/ai-friendly/05-error-handling.cs
-  WebCallResult pattern, transient retry, OKX error metadata.
+  HttpResult pattern, transient retry, OKX error metadata.
 ```
 
 These files are intended to be copied into a console `Program.cs` after `dotnet add package JK.OKX.Net`. In this repository, `OKX.Net.UnitTests/Documentation/AiExampleCompileTests.cs` compiles these examples against the local build.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -26,7 +26,9 @@ Primary documentation:
 - Include `using OKX.Net.Clients;` when constructing `OKXRestClient` or `OKXSocketClient`.
 - Always check `.Success` before reading `.Data`.
 - REST methods return `HttpResult<T>` or `HttpResult`.
-- WebSocket subscriptions and socket API requests return `WebSocketResult<T>` or `WebSocketResult`.
+- WebSocket subscription methods return `WebSocketResult<UpdateSubscription>`.
+- Socket API request/response methods return `QueryResult<T>`.
+- Shared symbol/cache helper methods can return `ExchangeCallResult<T>`.
 - Reuse clients. Do not instantiate a REST or socket client per request in production code.
 - Prefer dependency injection for long-running services.
 - Store WebSocket subscriptions and unsubscribe during shutdown.
@@ -35,7 +37,7 @@ Primary documentation:
 - Use OKX symbol format such as `BTC-USDT`, `ETH-USDT`, and `ETH-USDT-SWAP`; do not use Binance-style `BTCUSDT`.
 - Use `UnifiedApi`. OKX.Net does not expose separate `SpotApi`, `FuturesApi`, `SwapApi`, `MarginApi`, `UsdFuturesApi`, or `GeneralApi` roots.
 - For product-specific calls, route by `InstrumentType`, symbol format, `TradeMode`, `MarginMode`, and `PositionSide`.
-- For multi-exchange code, use `CryptoExchange.Net.SharedApis` interfaces from `client.UnifiedApi.SharedClient`.
+- For multi-exchange code, use `CryptoExchange.Net.SharedApis` interfaces from `client.UnifiedApi.SharedClient`; use `.SharedClient.Discover()` to inspect implemented shared interfaces and endpoint/subscription options at runtime.
 
 ## Installation
 
@@ -608,7 +610,14 @@ if (!ticker.Success)
 Console.WriteLine(ticker.Data.LastPrice);
 ```
 
-Shared WebSocket subscriptions return an `UpdateSubscription` in `.Data`. For shared interface variables, unsubscribe through the concrete socket client:
+Shared clients expose `Discover()` for runtime metadata about implemented shared interfaces, supported request options, and supported subscription options.
+
+```csharp
+var info = new OKXRestClient().UnifiedApi.SharedClient.Discover();
+Console.WriteLine(string.Join(", ", info.Features.Where(x => x.Supported).Select(x => x.EndpointName)));
+```
+
+Shared REST methods return `HttpResult<T>` or `HttpResult`. Shared symbol/cache helper methods can return `ExchangeCallResult<T>`. Shared WebSocket subscriptions return `WebSocketResult<UpdateSubscription>` with an `UpdateSubscription` in `.Data`. For shared interface variables, unsubscribe through the concrete socket client:
 
 ```csharp
 var socketClient = new OKXSocketClient();
@@ -731,10 +740,10 @@ Examples/ai-friendly/03-websocket.cs
   Public ticker stream, kline stream, authenticated order stream, success checks, teardown.
 
 Examples/ai-friendly/04-multi-exchange.cs
-  CryptoExchange.Net.SharedApis REST pattern for exchange-agnostic code.
+  CryptoExchange.Net.SharedApis REST and discovery pattern for exchange-agnostic code.
 
 Examples/ai-friendly/05-error-handling.cs
-  HttpResult pattern, transient retry, OKX error metadata.
+  HttpResult, QueryResult, WebSocketResult, transient retry, OKX error metadata.
 ```
 
 These files are intended to be copied into a console `Program.cs` after `dotnet add package JK.OKX.Net`. In this repository, `OKX.Net.UnitTests/Documentation/AiExampleCompileTests.cs` compiles these examples against the local build.

--- a/llms.txt
+++ b/llms.txt
@@ -17,7 +17,7 @@
 - [Derivatives Trading](https://github.com/JKorf/OKX.Net/blob/main/Examples/ai-friendly/02-derivatives.cs): Swap/futures symbols, leverage, market order, position retrieval, close position
 - [WebSocket Streams](https://github.com/JKorf/OKX.Net/blob/main/Examples/ai-friendly/03-websocket.cs): Public ticker/klines, private order stream, proper unsubscribe
 - [Multi-Exchange Pattern](https://github.com/JKorf/OKX.Net/blob/main/Examples/ai-friendly/04-multi-exchange.cs): Using CryptoExchange.Net SharedApis for exchange-agnostic code
-- [Error Handling](https://github.com/JKorf/OKX.Net/blob/main/Examples/ai-friendly/05-error-handling.cs): HttpResult pattern, retry logic, error metadata
+- [Error Handling](https://github.com/JKorf/OKX.Net/blob/main/Examples/ai-friendly/05-error-handling.cs): HttpResult, QueryResult, and WebSocketResult patterns, retry logic, error metadata
 
 ## Critical Usage Rules
 
@@ -25,8 +25,9 @@
 - Use `OKXCredentials("key", "secret", "passphrase")` for private endpoints.
 - Use `client.UnifiedApi.*`; OKX.Net does not expose separate `SpotApi` or `FuturesApi` roots.
 - Use OKX symbol format such as `BTC-USDT` and `BTC-USDT-SWAP`.
-- Check `.Success` before reading `.Data` on `HttpResult<T>` and `WebSocketResult<T>`.
-- For multi-exchange code use `client.UnifiedApi.SharedClient`.
+- Check `.Success` before reading `.Data` on `HttpResult<T>`, `HttpResult`, `WebSocketResult<UpdateSubscription>`, `QueryResult<T>`, and shared helper results.
+- REST calls return `HttpResult<T>` or `HttpResult`; socket subscriptions return `WebSocketResult<UpdateSubscription>`; socket API request/response methods return `QueryResult<T>`.
+- For multi-exchange code use `client.UnifiedApi.SharedClient`; call `SharedClient.Discover()` to inspect implemented shared interfaces and endpoint/subscription options at runtime.
 
 ## Reference
 

--- a/llms.txt
+++ b/llms.txt
@@ -17,7 +17,7 @@
 - [Derivatives Trading](https://github.com/JKorf/OKX.Net/blob/main/Examples/ai-friendly/02-derivatives.cs): Swap/futures symbols, leverage, market order, position retrieval, close position
 - [WebSocket Streams](https://github.com/JKorf/OKX.Net/blob/main/Examples/ai-friendly/03-websocket.cs): Public ticker/klines, private order stream, proper unsubscribe
 - [Multi-Exchange Pattern](https://github.com/JKorf/OKX.Net/blob/main/Examples/ai-friendly/04-multi-exchange.cs): Using CryptoExchange.Net SharedApis for exchange-agnostic code
-- [Error Handling](https://github.com/JKorf/OKX.Net/blob/main/Examples/ai-friendly/05-error-handling.cs): WebCallResult pattern, retry logic, error metadata
+- [Error Handling](https://github.com/JKorf/OKX.Net/blob/main/Examples/ai-friendly/05-error-handling.cs): HttpResult pattern, retry logic, error metadata
 
 ## Critical Usage Rules
 
@@ -25,7 +25,7 @@
 - Use `OKXCredentials("key", "secret", "passphrase")` for private endpoints.
 - Use `client.UnifiedApi.*`; OKX.Net does not expose separate `SpotApi` or `FuturesApi` roots.
 - Use OKX symbol format such as `BTC-USDT` and `BTC-USDT-SWAP`.
-- Check `.Success` before reading `.Data` on `WebCallResult<T>` and `CallResult<T>`.
+- Check `.Success` before reading `.Data` on `HttpResult<T>` and `WebSocketResult<T>`.
 - For multi-exchange code use `client.UnifiedApi.SharedClient`.
 
 ## Reference


### PR DESCRIPTION
* Result types:
  * (Web)CallResult types are replaced by HttpResult, WebSocketResult and QueryResult with the same logic
  * WebSocketResult and QueryResult now return additional info for websocket operations
  * Updated result types to record type
  * Removed implicit result type conversion to bool, `if (result)` no longer works, instead use `if (result.Success)`
  * Fixed result object nullability hinting, for example Data might be null if Success isn't checked for true

* Clients:
  * Added ToString overrides on base API types
  * Added Exchange property on BaseApiClient
  * Added ApiCredentials property on Api clients
  * Updated ILogger source from client name to topic specific client name
  * Removed logging from client creation
  * Fixed issue in SocketApiClient.GetSocketConnection causing requests to always wait the full max 10 seconds when there was a reconnecting socket

* Shared APIs:
  * Added missing dedicated option types
  * Added Discover method on ISharedClient interface, returning info on supported capabilities and operations
  * Added ResetStaticExchangeParameters method on ExchangeParameters
  * Added Status property to SharedWithdrawal model
  * Added TradingModes property to SharedBalance model
  * Added support for Europe environment XPerps when using Shared APIs by setting SharedApiEuropeUseXPerps in the client options
  * Updated Shared ExchangeParameters parameter names to be case insensitive
  * Updated code comments
  * Replaced ExchangeResult with ExchangeCallResult type
  * Removed TradingMode from the response model, only maintained on models where it makes sense
  * Fixed futures symbols cache overwriting when using different trading modes

* Added async streaming on UserDataTracker items with StreamUpdatesAsync
* Added cancellation token support to UserDataTracker starting
* Added SupportedEnvironments property to PlatformInfo
* Added Clear() method on UserClientProvider to clear all cached clients
* Added setter to OKXExchange.RateLimiter to allow custom rate limit settings
* Various small performance improvements
* Fixed websocket connection attempts counting towards rate limit even when server could not be reached